### PR TITLE
enhancements

### DIFF
--- a/docs/document_types.adoc
+++ b/docs/document_types.adoc
@@ -1,0 +1,77 @@
+=== Document Types
+
+ClarisWorks/AppleWorks supports multiple document types. The document type is stored as a 2-byte value at offset `0x80` in the file header.
+
+==== Document Type Values
+
+.Document Types
+[width="80%",grid="all", valign="top", options="header"]
+|=========================================================
+| Hex Value | Decimal | Document Type | Description
+
+| 0x0000 | 0 | Spreadsheet | Older spreadsheet format (v4 and earlier)
+| 0x0101 | 257 | Drawing | Vector drawing document
+| 0x0202 | 514 | Word Processing | Text document (most common)
+| 0x0303 | 771 | Spreadsheet | Version 5.x spreadsheet format
+| 0x1515 | 5397 | Painting | Bitmap/raster painting document
+|=========================================================
+
+==== Detection
+
+The document type is located at:
+
+* **Offset**: `0x80` (128 decimal)
+* **Size**: 2 bytes (big-endian short)
+
+==== Example Code
+
+[source,java]
+----
+// Read document type at offset 0x80
+dataInputStream.skipBytes(0x80 - currentPosition);
+short docType = dataInputStream.readShort();
+
+switch (docType) {
+    case 0x0202:
+        System.out.println("Word Processing document");
+        break;
+    case 0x0101:
+        System.out.println("Drawing document");
+        break;
+    case 0x1515:
+        System.out.println("Painting document");
+        break;
+    case 0x0000:
+    case 0x0303:
+        System.out.println("Spreadsheet document");
+        break;
+}
+----
+
+==== Hex Dump Examples
+
+.Word Processing Document (blank_6.2.9_osx.cwk)
+----
+00000080: 0202                                     ..
+----
+
+.Painting Document (blank_painting_6.2.9_osx.cwk)
+----
+00000080: 1515                                     ..
+----
+
+.Drawing Document (blank_drawing_6.2.9_osx.cwk)
+----
+00000080: 0101                                     ..
+----
+
+.Spreadsheet Document (sheet_B-5.0.3_os9.cwk)
+----
+00000080: 0303                                     ..
+----
+
+==== Notes
+
+* The byte values appear to be duplicated (e.g., `0x02 0x02` rather than just `0x02`), possibly for validation or alignment purposes.
+* Earlier documentation incorrectly identified the document type position as offsets 268 or 278. The correct position is `0x80` (128) for all tested versions.
+* The document type at `0x80` is consistent across ClarisWorks 4.x, 5.x, and AppleWorks 6.x files.

--- a/docs/etbl.adoc
+++ b/docs/etbl.adoc
@@ -1,0 +1,128 @@
+=== ETBL - End Table of Contents
+
+The ETBL block is located near the end of every ClarisWorks/AppleWorks file and contains a table of contents (index) of all major blocks in the document.
+
+==== Purpose
+
+The ETBL block allows random access to any block in the file without scanning. It maps 4-character block names to their byte offsets within the file.
+
+==== Structure
+
+.ETBL Block Format
+[width="80%",grid="all", valign="top", options="header"]
+|=========================================================
+| Offset | Size | Description | Example
+
+| 0 | 4 | Block identifier | `ETBL` (0x4554424C)
+| 4 | 4 | Total block size (big-endian) | 0x00000068 (104 bytes)
+| 8 | n*8 | Table entries (repeating) | See below
+|=========================================================
+
+.Table Entry Format (8 bytes each)
+[width="80%",grid="all", valign="top", options="header"]
+|=========================================================
+| Offset | Size | Description | Example
+
+| 0 | 4 | Block name (ASCII) | `DSUM`, `STYL`, `FNTM`, etc.
+| 4 | 4 | Block offset in file (big-endian) | 0x00000AD5
+|=========================================================
+
+==== Common Block Names
+
+.Known Block Types
+[width="80%",grid="all", valign="top", options="header"]
+|=========================================================
+| Name | Description
+
+| DSUM | Document Summary (metadata)
+| HDNI | Header Info
+| STYL | Style definitions
+| MCRO | Macros
+| oBlN | Binary block offsets
+| MARK | Markers
+| WMBT | Unknown (window/workbook related?)
+| SNAP | Snapshot/Thumbnail (PICT format)
+| TNAM | Template Name
+| CPRT | Print settings (XML plist in v6)
+| ETBL | Self-reference (points to this block)
+|=========================================================
+
+==== Location
+
+The ETBL block is always located near the end of the file, followed only by the file end marker.
+
+==== File End Marker
+
+Immediately after the ETBL block content is the 16-byte file end marker:
+
+----
+FF FE FD FC FB FA F9 F8 F0 F1 F2 F3 F4 F5 F6 F7
+----
+
+This marker is present in all tested ClarisWorks/AppleWorks files and can be used to verify file integrity.
+
+==== Example
+
+.ETBL from blank_6.2.9_osx.cwk
+----
+00003BE4: 45 54 42 4C  00 00 00 68  44 53 55 4D  00 00 0A D5  ETBL...hDSUM....
+00003BF4: 48 44 4E 49  00 00 0A F5  53 54 59 4C  00 00 0A FF  HDNI....STYL....
+00003C04: 4D 43 52 4F  00 00 13 9D  6F 42 6C 4E  00 00 13 AD  MCRO....oBlN....
+00003C14: 4D 41 52 4B  00 00 13 B9  57 4D 42 54  00 00 13 DF  MARK....WMBT....
+00003C24: 53 4E 41 50  00 00 13 EB  54 4E 41 4D  00 00 16 F6  SNAP....TNAM....
+00003C34: 43 50 52 54  00 00 17 1D  45 54 42 4C  00 00 3B E4  CPRT....ETBL..;.
+00003C44: FF FE FD FC  FB FA F9 F8  F0 F1 F2 F3  F4 F5 F6 F7  ................
+----
+
+Parsed entries:
+----
+DSUM -> 0x00000AD5 (2773)
+HDNI -> 0x00000AF5 (2805)
+STYL -> 0x00000AFF (2815)
+MCRO -> 0x0000139D (5021)
+oBlN -> 0x000013AD (5037)
+MARK -> 0x000013B9 (5049)
+WMBT -> 0x000013DF (5087)
+SNAP -> 0x000013EB (5099)
+TNAM -> 0x000016F6 (5878)
+CPRT -> 0x0000171D (5917)
+ETBL -> 0x00003BE4 (15332) [self-reference]
+----
+
+==== Parsing Code
+
+[source,java]
+----
+public Map<String, Integer> parseETBL(byte[] allBytes) {
+    Map<String, Integer> blockIndex = new HashMap<>();
+
+    // Find the last occurrence of ETBL
+    int etblPos = findLastPattern(allBytes, new byte[]{0x45, 0x54, 0x42, 0x4C});
+
+    if (etblPos < 0) {
+        return blockIndex;
+    }
+
+    // Read size
+    int size = getArrayInt(allBytes, etblPos + 4);
+
+    // Parse entries
+    int pos = etblPos + 8;
+    int endPos = etblPos + 4 + size;
+
+    while (pos + 8 <= endPos) {
+        String blockName = new String(Arrays.copyOfRange(allBytes, pos, pos + 4));
+        int offset = getArrayInt(allBytes, pos + 4);
+
+        // Stop if we hit the file end marker
+        if (blockName.charAt(0) == (char) 0xFF) {
+            break;
+        }
+
+        blockIndex.put(blockName, offset);
+        pos += 8;
+    }
+
+    return blockIndex;
+}
+----

--- a/docs/fonts.adoc
+++ b/docs/fonts.adoc
@@ -1,0 +1,114 @@
+=== FNTM - Font Map Block
+
+The FNTM block contains the list of fonts used in the document. Each font entry is 69 bytes (0x45) in size.
+
+==== Block Structure
+
+.FNTM Block Format
+[width="80%",grid="all", valign="top", options="header"]
+|=========================================================
+| Offset | Size | Description | Example
+
+| 0 | 4 | Block identifier | `FNTM` (0x464E544D)
+| 4 | 4 | Block size (big-endian) | Varies
+| 8 | n | Font entries (69 bytes each) | See below
+|=========================================================
+
+==== Font Entry Format
+
+Each font entry is exactly 69 bytes (0x45):
+
+.Font Entry Structure
+[width="80%",grid="all", valign="top", options="header"]
+|=========================================================
+| Offset | Size | Description | Example
+
+| 0 | 2 | Entry header | 0x0015 (observed pattern)
+| 2 | 2 | Font index/flags | 0x0002
+| 4 | 1 | Font name length | 0x09 (9 characters)
+| 5 | 64 | Font name (null-padded) | "Helvetica\0\0\0..."
+|=========================================================
+
+==== Common Fonts
+
+Fonts commonly found in ClarisWorks/AppleWorks documents:
+
+* Helvetica
+* Geneva
+* Times
+* Arial
+* Courier
+* Palatino
+* Chicago
+
+==== Character Encoding
+
+Font names use **MacRoman** character encoding, which is the standard encoding for classic Mac OS applications.
+
+==== Example
+
+.FNTM block from brownfoxstyle_6.2.9_osx.cwk
+----
+00001410: 0002 464E 544D  0015 0002 0948 656C 7665  ..FNTM.....Helve
+00001420: 7469 6361 0000 0000 0000 0000 0000 0000  tica............
+00001430: 0000 0000 0000 0000 0000 0000 0000 0000  ................
+00001440: 0000 0000 0000 0000 0000 0000 0000 0000  ................
+00001450: 0000 0000 0000 0000 0000 0015 0002 0647  ...............G
+00001460: 656e 6576 6100 0000 0000 0000 0000 0000  eneva...........
+...
+00001490: 0000 0000 0000 0000 0000 0000 0000 0015  ................
+000014A0: 0002 0554 696d 6573 0000 0000 0000 0000  ...Times........
+----
+
+Parsed fonts:
+----
+[0] Helvetica
+[1] Geneva
+[2] Times
+----
+
+==== Parsing Code
+
+[source,java]
+----
+static final int FONT_ENTRY_SIZE = 0x45; // 69 bytes
+
+public void parseFonts(byte[] allBytes, Document doc) {
+    int fntmPos = findPattern(allBytes, new byte[]{0x46, 0x4E, 0x54, 0x4D}, 0);
+
+    if (fntmPos < 0) {
+        return;
+    }
+
+    int pos = fntmPos + 4;
+    int blockSize = getArrayInt(allBytes, pos);
+    pos += 4;
+
+    while (pos < fntmPos + 4 + blockSize && pos + FONT_ENTRY_SIZE < allBytes.length) {
+        // Check for font entry header pattern
+        if (allBytes[pos] == 0x00 && allBytes[pos + 1] == 0x15) {
+            pos += 4; // Skip header and index
+
+            int nameLen = allBytes[pos] & 0xFF;
+            pos++;
+
+            if (nameLen > 0 && nameLen < 64) {
+                String fontName = new String(
+                    Arrays.copyOfRange(allBytes, pos, pos + nameLen),
+                    Charset.forName("MacRoman")).trim();
+                doc.addFont(fontName);
+            }
+
+            pos += (FONT_ENTRY_SIZE - 5);
+        } else {
+            pos++;
+        }
+    }
+}
+----
+
+==== Notes
+
+* The font index in each entry can be used to reference fonts from style runs in the CHAR block.
+* Font entries are always 69 bytes, regardless of font name length (names are null-padded).
+* The entry header pattern `0x0015` appears consistent across tested files.

--- a/docs/header.adoc
+++ b/docs/header.adoc
@@ -1,85 +1,118 @@
 === Document Header
 
+The document header contains metadata about the ClarisWorks/AppleWorks file including version, page dimensions, margins, and document type.
+
 .Document Header
-[width="80%",grid="all", valign="top", options="header"]
+[width="100%",grid="all", valign="top", options="header"]
 |=========================================================
 |chunk id |position start |length (bytes) |description |example |ascii or int |comments
 
 |  1 |  0 |  1 |  major version |  05 +
-06 | |  confirmed
+06 | |  5 = ClarisWorks 5.x, 6 = AppleWorks 6.x
 
-|  2 |  2 |  3 |  additional version |  029900 +
-07E100 | |  appears somewhat random but is specific to minor version, maybe platform
+|  2 |  1 |  1 |  minor version |  07 +
+02 | |  Minor version number
 
-| 3 | 8 | 4 | creator type | 424F424F | BOBO | Always has the same value
+|  3 |  2 |  2 |  build/platform identifier |  E100 +
+9900 | |  Platform-specific: E100 = OSX, 9900 = Windows
 
-| 4 | 8 | 4 | previous version | 029900 +
-07E100 | | If file was converted this will contain the previous major and additional version number. If not converted it will be the same as 0-8
+| 4 | 4 | 4 | creator signature | 424F424F | BOBO | Always "BOBO" - validates file format
 
-| 5 | 12 | 8 |  | 0x00000000 0x00000000 | | seems to always be full of zeros
+| 5 | 8 | 4 | previous version | 0607E100 +
+05029900 | | If file was converted, contains original version. Otherwise matches bytes 0-3
 
-| 6 | 20 | 2 | | 0x0001 | | seems to always be 0x0001
+| 6 | 12 | 8 | reserved | 0x00000000 0x00000000 | | Always zeros
 
-| 7 | 22 | 2 |  | 0x0194 +
-0x01CD | | some sort of marker - will appear not too far ahead of this block.
+| 7 | 20 | 2 | unknown | 0x0001 | | Consistently 0x0001
 
-| 8 | 24 | 2 | | | | is usually the same after each instance of block, but sometimes different.
+| 8 | 22 | 2 | marker | 0x0194 +
+0x01CD | | Version-specific marker value
 
-| 9 | 26 | 4 | | 0x00000000 | |
+| 9 | 24 | 2 | unknown | | | Varies between files
 
+| 10 | 26 | 4 | reserved | 0x00000000 | | Always zeros
 
-|10 |30 | 2 | page height | | 792 +
-612 | page width in pts. ie: 792x612 for portrait,  612x792 for landscape
+| 11 | 30 | 2 | page height | 0x0318 +
+0x0264 | 792 +
+612 | Page height in points (72 pts = 1 inch). 792 = 11", 612 = 8.5"
 
-|11 |32 | 2 | page width | | |
+| 12 | 32 | 2 | page width | 0x0264 +
+0x0318 | 612 +
+792 | Page width in points. Portrait: 612x792, Landscape: 792x612
 
-|12 |34 | 12 | margins | 0x0048 0x0048 0x0048 0x0048 0x0048 0x0048 | HHHHHH | link:margins.adoc[margins]
+| 13 | 34 | 2 | margin top | 0x0048 | 72 | Top margin in points (72 = 1 inch)
 
-|13 |46 | 2 | inner height | | | will be equal to #10 minus either right or left, not sure which yet
+| 14 | 36 | 2 | margin left | 0x0048 | 72 | Left margin in points
 
-|14 |48 | 2 | inner width | | | will be equal to #11 minus either top or bottom margin, not sure which yet
+| 15 | 38 | 2 | margin bottom | 0x0048 | 72 | Bottom margin in points
 
-|15 |50 | 1 | | 0x01 | | same in all files tested - probably a flag
+| 16 | 40 | 2 | margin right | 0x0048 | 72 | Right margin in points
 
-|16 |51 | 1 | | 0x00 | | same in all files tested - probably a flag
+| 17 | 42 | 2 | margin 5 | 0x0048 | 72 | Additional margin (header/gutter?)
 
-|17 |52 | 1 | | 0x01 | | same in all files tested - probably a flag
+| 18 | 44 | 2 | margin 6 | 0x0048 | 72 | Additional margin (footer/gutter?)
 
-|18 |53 | 1 | | 0x00 | | same in all files tested - probably a flag
+| 19 | 46 | 2 | inner height | 0x02D0 | 720 | Printable area height (page - top/bottom margins)
 
-|19 |54 | 4 | | 0x00000000 | | unknown
+| 20 | 48 | 2 | inner width | 0x021C | 540 | Printable area width (page - left/right margins)
 
-|20 |58 | 4 | | 0x00000000 | | unknown
+| 21 | 50 | 2 | flags | 0x0100 | | Unknown flags
 
-|21 |58 | 4 | | 0x00000000 | | unknown
+| 22 | 52 | 2 | flags | 0x0001 | | Unknown flags
 
-|22 |62 | 4 | | 0x00000000 | | unknown
+| 23 | 54 | 76 | reserved/unknown | | | Various flags and reserved bytes
 
-|23 |66 | 4 | | 0x00000000 | | unknown
-
-|24 |70 | 4 | | 0x00000100 | | unknown
-
-|25 |74 | 4 | | | | unknown
-
-|26 |78 | 4 | | | | unknown
-
-|27 |82 | 4 | | | | unknown
-
-|28 |86 | 4 | | 0x00000005 | | unknown
-
-|29 |90 | 2 | | 0xFFFF | |
-
-|30 |? | 4 | end header??? | 7FFFFFFF | | appears in all files tested. position:  +
-680 - 5.0v1 +
-672 - 6.2.9
-
-|31 |after last block | 4 | length of next block after next | | | 
-
-|32 |after last | 46 | unknown | | |
-
-|33 |after last | determined by number in #21 | unknown | | |
+| 24 | 128 (0x80) | 2 | **document type** | 0x0202 +
+0x0101 +
+0x1515 | | See link:document_types.adoc[document_types]. +
+0x0202 = Word Processing +
+0x0101 = Drawing +
+0x1515 = Painting +
+0x0303 = Spreadsheet
 
 |=========================================================
 
+==== Paper Size Values
 
-*there is a 2 byte delimiter shortly after the header that is used throughout the document.
+Common paper sizes observed in test files:
+
+.Paper Sizes
+[width="80%",grid="all", valign="top", options="header"]
+|=========================================================
+| Paper | Height (hex) | Height (pts) | Width (hex) | Width (pts) | Orientation
+
+| US Letter | 0x0318 | 792 | 0x0264 | 612 | Portrait
+| US Letter | 0x0264 | 612 | 0x0318 | 792 | Landscape
+| US Legal | 0x03F0 | 1008 | 0x0264 | 612 | Portrait
+| A5 | 0x0253 | 595 | 0x01A4 | 420 | Portrait
+|=========================================================
+
+==== Version Detection
+
+The version can be used to determine file compatibility:
+
+* **Major version 5**: ClarisWorks 5.x (Windows or Mac OS 9)
+* **Major version 6**: AppleWorks 6.x (Mac OS X)
+
+The build identifier at bytes 2-3 can help identify the platform:
+
+* **E100**: Mac OS X
+* **9900**: Windows
+* **AD00**: Mac OS 9 (observed in v5 files)
+
+==== File End Marker
+
+All ClarisWorks/AppleWorks files end with a 16-byte marker:
+
+----
+FF FE FD FC FB FA F9 F8 F0 F1 F2 F3 F4 F5 F6 F7
+----
+
+This marker always appears after the link:etbl.adoc[ETBL] block and can be used to verify file integrity.
+
+==== Notes
+
+* All multi-byte values are stored in big-endian format.
+* Character strings use MacRoman encoding.
+* Page dimensions are in points (72 points = 1 inch).
+* Earlier documentation incorrectly identified document type position. The correct position is **0x80** (128).

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -1,6 +1,6 @@
 = Introduction
 
-Clarisworks / Appleworks documents are a closed file format. This page is an
+ClarisWorks / AppleWorks documents are a closed file format. This page is an
 attempt to describe this format(s) for the purpose of importing documents into
 newer more open formats for archiving.
 
@@ -13,32 +13,64 @@ continuing work until I have enough knowledge to develop a reader that can at
 least extract text and some basic formatting of simple documents. From what I
 can tell, I think this first goal can be met. If anyone else out there can
 find anything else on their own, please update this wiki or email me your thoughts.
-code and test files can be found at: https://github.com/teacurran/appleworks-parser
+Code and test files can be found at: https://github.com/teacurran/appleworks-parser
+
+== Supported Versions
+
+* ClarisWorks 4.x (partial)
+* ClarisWorks 5.x (Windows and Mac OS 9)
+* AppleWorks 6.x (Mac OS X)
+
+== Current Capabilities
+
+* ✅ Document version detection
+* ✅ Document type detection (Word Processing, Drawing, Painting, Spreadsheet)
+* ✅ Page dimensions and margins
+* ✅ Text content extraction
+* ✅ Font list extraction (FNTM block)
+* ✅ Block index parsing (ETBL table of contents)
+* ✅ Conversion to ODF format
+* ⚠️ Style runs (partial - structure identified but not fully parsed)
+* ❌ Embedded images
+* ❌ Spreadsheet cell data
+* ❌ Drawing/painting graphics
 
 == Priorities
 
-* discover how to determine the start of the content block
-* Figure out the format of DSET
-* discover how to read the style attributes to apply to the content
-* develop plugin for Xena
-* develop plugin for general use
+* ✅ Discover how to determine the start of the content block
+* ✅ Figure out the format of DSET
+* ⚠️ Discover how to read the style attributes to apply to the content (in progress)
+* ❌ Develop plugin for Xena
+* ❌ Develop plugin for general use
 
 == Example Files
 
-example files I am using can be found in test_files directory
+Example files I am using can be found in the `test_files` directory.
 
 Please email me any examples you might have, especially if you have a version of
 ClarisWorks older than 5.0.
 
 == Document Format
+
+The following sections describe the binary format of ClarisWorks/AppleWorks files.
+
+include::header.adoc[]
+
+include::document_types.adoc[]
+
 include::keywords.adoc[]
 
 include::markers.adoc[]
 
-include::header.adoc[]
+include::etbl.adoc[]
+
+include::fonts.adoc[]
+
+include::style_runs.adoc[]
 
 === Document Info
-*there is a summary stored after the main header but before the first DSET
+
+There is a summary stored after the main header but before the first DSET.
 
 .Document Info
 [width="80%",grid="all", valign="top", options="header"]
@@ -56,47 +88,49 @@ include::header.adoc[]
 ** Category
 ** Description
 
-*each field is allowed 255 bytes of content +
-*full content is always available in the [[Projects:Archiving:AppleWorks:DSUM|DSUM]] section
+*Each field is allowed 255 bytes of content +
+*Full content is always available in the DSUM section
 
 === Document Content
-Content Appears to start right after the end of the first DSET block
 
-Strings in the document start with the first 4 bytes indicating the length of the string
+Content appears to start right after the end of the first DSET block.
 
-The content area will have several strings in a row without any termination
+Strings in the document start with the first 4 bytes indicating the length of the string.
+
+The content area will have several strings in a row without any termination.
 
 The last string appears to be null terminated.
 
-footnotes show up in the text as 0x02
+Footnotes show up in the text as 0x02.
 
-=== Document TOC
-The TOC can contain any number of markers in any order. The data area always starts and ends with ETBL.
+Character encoding is MacRoman.
 
-.Document TOC - at end of file
-[width="80%",grid="all", valign="top", options="header"]
-|=========================================================
-|position start |length (bytes)| description |example |ascii |comments
-|start position determined by other ETBL |4 |tag |4554424C |ETBL |Value indicates the total length of data in ETBL
-|anywhere |4 |data | |oBIN |oBIN block offset from start of doc
-|anywhere |4 |tag |4453554D |DSUM |DSUM block offset
-|anywhere |4 |data | |STYL |STYL block offset
-|anywhere |4 |data || BBAR |
-|anywhere |4 |data || MARK| MARK block offset
-|anywhere |4 |data || MRKS |
-|EOF - 24 |4 |tag |4554424C |ETBL |Following Value indicates start position
-|=========================================================
+=== Document TOC (ETBL)
+
+The ETBL block at the end of the file contains a table of contents with offsets to all major blocks.
+See link:etbl.adoc[ETBL documentation] for detailed structure.
+
+== File Validation
+
+=== BOBO Signature
+
+All valid ClarisWorks/AppleWorks files contain the ASCII string "BOBO" at offset 4-7.
+
+=== File End Marker
+
+In all versions tested, documents end with:
+----
+FF FE FD FC FB FA F9 F8 F0 F1 F2 F3 F4 F5 F6 F7
+----
+
+This 16-byte marker always follows the ETBL block and can be used to verify file integrity.
 
 == Misc
 
-in both versions tested, document ends with: +
-FF FE FD FC FB FA F9 F8 F0 F1 F2 F3 F4 F5 F6 F7
-
 === Passwords
-* password protected documents do not have their content protected.
-* password is not stored in the file
-* it probably stores a checksum because there isn't much difference in password length
-
+* Password protected documents do not have their content protected.
+* Password is not stored in the file.
+* It probably stores a checksum because there isn't much difference with password length.
 
 == Other Efforts
 
@@ -109,20 +143,19 @@ If you do a ton of google searches, you find a lot of pages that say that
 StarOffice could open ClarisWorks documents. This was done with the W4W filter.
 After a lot of digging, I believe that these filters live in OpenOffice in the
 Framework project. After checking out the source for the Framework project, I
-believe that the ClarisWorks import support was non-existant. If I am reading
+believe that the ClarisWorks import support was non-existent. If I am reading
 the source correctly, it looks like this filter simply opens the document as
 ASCII. If this is the case, I don't know why they even bothered to say they
-had a filter, if this is not the case someone please correct me.
+had a filter. If this is not the case someone please correct me.
 
-=== Propriatary
-* Old versions of DataViz can convert documents. product appears dead but
+=== Proprietary
+* Old versions of DataViz can convert documents. Product appears dead but
 still for sale.
-* MacText can convert older .cwk files to rtf, word2, and Word Perfect
+* MacText can convert older .cwk files to rtf, word2, and Word Perfect.
 * XTND - there is a lot of info out there about XTND filters as part of
 system 6 and 7. I would like to investigate if copies of these filters
 could help this effort but I haven't been able to find enough info yet.
 
 == Misc
-Forum message from someone looking into the format (from 2001, ha!)
+Forum message from someone looking into the format (from 2001):
 http://www.justlinux.com/forum/showthread.php?p=228151
-

--- a/docs/keywords.adoc
+++ b/docs/keywords.adoc
@@ -1,71 +1,81 @@
 === Keywords
 
+Block keywords are 4-byte ASCII identifiers that mark the start of data blocks within ClarisWorks/AppleWorks files.
+
 .Keywords
-[width="80%",grid="all", valign="top", options="header"]
+[width="100%",grid="all", valign="top", options="header"]
 |=========================================================
-|keyword |type |can contain |description |notes
+|keyword |hex |type |description |notes
 
-|BBAR | | | |
+|BBAR |42424152 | |Button bar |
 
-|CHAR | | | |
+|CHAR |43484152 |variable |Character style runs |Contains text formatting information (bold, italic, etc.). See link:style_runs.adoc[style_runs]. First 4 bytes after keyword indicate length.
 
-|CELL | | | |
+|CELL |43454C4C | |Cell formatting |Used in spreadsheets and style definitions
 
-|CPRT |variable | | |first 4 bytes indicate length of block<br>v6 contains xml with printing information
+|CPRT |43505254 |variable |Print settings |First 4 bytes indicate length. In v6, contains XML plist with printing information (resolution, paper size, orientation, etc.)
 
-|link:DSET.adoc[DSET] | | | |appear to have a format like: +
-4 byte Len +
-value +
-4 byte Len +
-value +
-continuing, +
-not sure when it ends.
+|CTAB |43544142 |variable |Cell table |Spreadsheet-specific block containing cell data
 
-|link:DSUM.adoc[DSUM] |variable | |Document summary |First 4 bytes indicate length of block
+|DSET |44534554 |blocked |Dataset |Contains 5 sub-blocks. First DSET is followed by document content. Format: 4-byte length + value, repeating.
 
-|ETBL | | | |
+|DSUM |4453554D |variable |Document summary |First 4 bytes indicate length. Contains metadata: title, author, version, keywords, category, description.
 
-|link:FNTM.adoc[FNTM] |blocked | |something to do with fonts |
+|ETBL |4554424C |variable |End table (TOC) |Table of contents at end of file. Maps block names to offsets. See link:etbl.adoc[etbl]. Followed by file end marker.
 
-|GRPH | | | |
+|FNTM |464E544D |blocked |Font map |List of fonts used in document. Each font entry is 69 bytes. See link:fonts.adoc[fonts].
 
-|link:HASH.adoc[HASH] | | | | Appears in multiples of 2? +
-always preceded by: FF FF 00 00 00 06 00 04 00 01
+|GRPH |47525048 | |Graphics |Graphics/drawing data
 
-|HDNI |variable | | |First 4 bytes indicate length of block
+|HASH |48415348 | |Hash table |Appears in multiples. Preceded by: FF FF 00 00 00 06 00 04 00 01
 
-|KSEN | | | |preceded by?: FF FF 00 00 00 0E 00 0A 00 02
+|HDNI |48444E49 |variable |Header info |First 4 bytes indicate length
 
-|LKUP | | | |preceded by?: FF FF 00 00 00 02 00 04 00 02
+|KSEN |4B53454E | |Unknown |Preceded by: FF FF 00 00 00 0E 00 0A 00 02
 
-|LOM! | | | | don't know if this is a keyword but putting it here just in case
+|LKUP |4C4B5550 | |Lookup |Preceded by: FF FF 00 00 00 02 00 04 00 02
 
-|NAME | | | |
+|LOM! |4C4F4D21 | |Unknown |Appears in v6 OSX files. In v5 Windows files, appears reversed as !MOL (possible endianness indicator)
 
-|link:RULR.adoc[RULR] | | | | probably page rulers<br>unable to determine the length
+|MARK |4D41524B |variable |Markers |First 4 bytes indicate length. Contains MRKS and MOBJ sub-blocks.
 
-|MARK | |MRKS +
-MOBJ | |First 4 bytes indicate length of block
+|MCRO |4D43524F | |Macros |Macro definitions
 
-|MRKS | | | |
+|MOBJ |4D4F424A | |Marker object |Sub-block within MARK
 
-|oBIN | | | |
+|MRKS |4D524B53 | |Markers list |Sub-block within MARK
 
-|SNAP |variable | |snapshot |First 4 bytes indicate length of block +
-then there is 5 bytes that are unknown, probably payload type, then a
-[http://www.fileformat.info/format/macpict/egff.htm PICT] file. +
-+
-possibly v6 only.
+|NAME |4E414D45 | |Named styles |Style names (e.g., "Default", "Header", "Body", "Footer", "Footnote")
 
-|link:STYL.adoc[STYL] | |HASH +
-NAME +
-FNTM +
-CELL +
-GRPH +
-RULR | | First 4 bytes indicate length of block
+|oBIN |6F42494E | |Binary offset |Binary block offset references
 
-|TNAM | | | |Different on every save
+|RULR |52554C52 | |Ruler |Page rulers and paragraph formatting
 
-|WMBT | | | |
+|SNAP |534E4150 |variable |Snapshot/thumbnail |First 4 bytes indicate length. Contains PICT format thumbnail image. 5 header bytes before PICT data. Possibly v6 only.
+
+|STYL |5354594C |variable |Styles |Contains sub-blocks: HASH, NAME, FNTM, CELL, GRPH, RULR. First 4 bytes indicate length.
+
+|TNAM |544E414D | |Template name |Changes on every save (possibly checksum or UUID)
+
+|WMBT |574D4254 | |Unknown |Window/workbook related?
 
 |=========================================================
+
+==== Block Format
+
+Most variable-length blocks follow this format:
+
+----
+[KEYWORD]  (4 bytes, ASCII)
+[LENGTH]   (4 bytes, big-endian integer)
+[DATA]     (LENGTH bytes)
+----
+
+==== Finding Blocks
+
+Blocks can be found by:
+
+1. **Sequential scanning**: Search for 4-byte keyword patterns
+2. **ETBL lookup**: Parse the ETBL block at end of file to get direct offsets to all major blocks
+
+The ETBL approach is more efficient for random access to specific blocks.

--- a/docs/style_runs.adoc
+++ b/docs/style_runs.adoc
@@ -1,0 +1,144 @@
+=== CHAR - Character Style Runs
+
+The CHAR block contains style run information that defines formatting applied to ranges of text in word processing documents.
+
+==== Purpose
+
+Style runs define which portions of text have specific formatting (bold, italic, underline, font changes, etc.). Each run specifies a character range and the styles applied to it.
+
+==== Block Structure
+
+.CHAR Block Format
+[width="80%",grid="all", valign="top", options="header"]
+|=========================================================
+| Offset | Size | Description | Example
+
+| 0 | 4 | Block identifier | `CHAR` (0x43484152)
+| 4 | 4 | Additional header info | Varies
+| 8+ | n*20 | Style run entries (~20 bytes each) | See below
+|=========================================================
+
+==== Style Run Entry Format (Approximate)
+
+Style run entries are approximately 20 bytes each. The exact structure is still being reverse-engineered:
+
+.Style Run Entry Structure
+[width="80%",grid="all", valign="top", options="header"]
+|=========================================================
+| Offset | Size | Description | Observed Values
+
+| 0 | 2 | Style flags | 0x0C01 (normal), 0x0901 (bold?), 0x0E01 (italic?), 0x0A01 (underline?)
+| 2 | 4 | Unknown | Usually 0x00000000
+| 6 | 2 | Unknown | 0x0300 observed
+| 8 | 2 | Unknown | Often 0xFFFF
+| 10 | 2 | Unknown | Varies
+| 12 | 2 | Text length/span | Length of styled text
+| 14 | 2 | Character offset | Cumulative position in text
+| 16 | 4 | Unknown | Varies
+|=========================================================
+
+==== Style Flag Values (Tentative)
+
+These values have been observed but require further verification:
+
+.Style Flags
+[width="80%",grid="all", valign="top", options="header"]
+|=========================================================
+| Flag Value | Style
+
+| 0x0C01 | Normal (no style)
+| 0x0901 | Bold (tentative)
+| 0x0E01 | Italic (tentative)
+| 0x0A01 | Underline (tentative)
+|=========================================================
+
+==== Example
+
+.CHAR block from brownfoxstyle_6.2.9_osx.cwk
+----
+00000DC0: 001A 000A 0002 4348 4152 01CD D3E8 0000  ......CHAR......
+00000DD0: FFFF 0000 0001 00FF FFFF 0000 0000 0000  ................
+00000DE0: 0000 0C01 0000 0000 0300 0000 0000 0005  ................
+00000DF0: 0000 0000 00FF FFFF 0000 0000 0C01 0000  ................
+00000E00: 0000 0300 FFFF 0000 0001 0000 0005 00FF  ................
+00000E10: FFFA 0001 0000 0901 0000 0000 0300 FFFF  ................
+00000E20: 0000 0001 0000 0016 00FF FFEB 0000 0001  ................
+00000E30: 0E01 0000 0000 0300 FFFF 0000 0001 0000  ................
+----
+
+==== Comparison: Plain vs Styled
+
+The CHAR block in a styled document contains more entries than in a plain document:
+
+.Plain document CHAR block
+----
+Fewer style run entries, mostly 0x0C01 (normal) style
+----
+
+.Styled document CHAR block
+----
+Multiple entries with varying style flags (0x0901, 0x0E01, 0x0A01, etc.)
+Additional entries for each style change in the text
+----
+
+==== Integration with Content
+
+Style runs reference positions within the document content. To apply styles:
+
+1. Parse the document content from DSET blocks
+2. Parse style runs from CHAR block
+3. Match style run offsets to character positions in content
+4. Apply appropriate formatting
+
+==== Parsing Code (Basic)
+
+[source,java]
+----
+public class StyleRun {
+    public static final int FLAG_NORMAL = 0x0C01;
+    public static final int FLAG_BOLD = 0x0901;
+    public static final int FLAG_ITALIC = 0x0E01;
+    public static final int FLAG_UNDERLINE = 0x0A01;
+
+    private int startOffset;
+    private int endOffset;
+    private int styleFlags;
+    private boolean bold;
+    private boolean italic;
+    private boolean underline;
+
+    public StyleRun(int startOffset, int endOffset, int styleFlags) {
+        this.startOffset = startOffset;
+        this.endOffset = endOffset;
+        this.styleFlags = styleFlags;
+        parseStyleFlags(styleFlags);
+    }
+
+    private void parseStyleFlags(int flags) {
+        switch (flags) {
+            case FLAG_BOLD:
+                this.bold = true;
+                break;
+            case FLAG_ITALIC:
+                this.italic = true;
+                break;
+            case FLAG_UNDERLINE:
+                this.underline = true;
+                break;
+        }
+    }
+}
+----
+
+==== Notes
+
+* The CHAR block structure requires more analysis for complete understanding.
+* Style flags interpretation is tentative and based on observed patterns.
+* Font size and font family references may be encoded in the unknown fields.
+* The relationship between CHAR and STYL blocks needs further investigation.
+
+==== Related Blocks
+
+* **STYL** - Contains named style definitions (e.g., "Default", "Header", "Body")
+* **FNTM** - Contains font names referenced by font index in style runs
+* **RULR** - Contains ruler/paragraph formatting settings

--- a/parser/pom.xml
+++ b/parser/pom.xml
@@ -24,7 +24,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.7</version>
+			<version>2.14.0</version>
 		</dependency>
 
 		<dependency>

--- a/parser/src/main/java/com/wirelust/appleworks/Document.java
+++ b/parser/src/main/java/com/wirelust/appleworks/Document.java
@@ -1,15 +1,116 @@
 package com.wirelust.appleworks;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 /**
  * Date: 19-Oct-2015
  *
  * @author T. Curran
+ *
+ * Represents a parsed AppleWorks/ClarisWorks document.
+ * Document types are determined by the 2-byte value at offset 0x80.
  */
 public class Document {
-	public static final int TYPE_TEXT = 1;
-	public static final int TYPE_PAINTING = 4;
 
-	int type;
+	// Document type constants (2-byte values at offset 0x80-0x81)
+	public static final int TYPE_SPREADSHEET = 0x0000;
+	public static final int TYPE_DRAWING = 0x0101;
+	public static final int TYPE_TEXT = 0x0202;
+	public static final int TYPE_SPREADSHEET_V5 = 0x0303;
+	public static final int TYPE_PAINTING = 0x1515;
+
+	// Version information
+	private int majorVersion;
+	private int minorVersion;
+	private int buildVersion;
+	private int previousMajorVersion;
+	private int previousMinorVersion;
+	private int previousBuildVersion;
+
+	// Document type
+	private int type;
+
+	// Page dimensions (in points, 72 points = 1 inch)
+	private short pageHeight;
+	private short pageWidth;
+	private short innerHeight;
+	private short innerWidth;
+
+	// Margins (in points)
+	private short marginTop;
+	private short marginLeft;
+	private short marginBottom;
+	private short marginRight;
+	private short margin5;
+	private short margin6;
+
+	// Font information from FNTM block
+	private List<String> fonts = new ArrayList<>();
+
+	// Style runs from CHAR block
+	private List<StyleRun> styleRuns = new ArrayList<>();
+
+	// Block index from ETBL (maps block name to file offset)
+	private Map<String, Integer> blockIndex = new HashMap<>();
+
+	// Thumbnail image data from SNAP block (PICT format)
+	private byte[] thumbnail;
+
+	// Document content
+	private String content;
+
+	// Getters and Setters
+
+	public int getMajorVersion() {
+		return majorVersion;
+	}
+
+	public void setMajorVersion(int majorVersion) {
+		this.majorVersion = majorVersion;
+	}
+
+	public int getMinorVersion() {
+		return minorVersion;
+	}
+
+	public void setMinorVersion(int minorVersion) {
+		this.minorVersion = minorVersion;
+	}
+
+	public int getBuildVersion() {
+		return buildVersion;
+	}
+
+	public void setBuildVersion(int buildVersion) {
+		this.buildVersion = buildVersion;
+	}
+
+	public int getPreviousMajorVersion() {
+		return previousMajorVersion;
+	}
+
+	public void setPreviousMajorVersion(int previousMajorVersion) {
+		this.previousMajorVersion = previousMajorVersion;
+	}
+
+	public int getPreviousMinorVersion() {
+		return previousMinorVersion;
+	}
+
+	public void setPreviousMinorVersion(int previousMinorVersion) {
+		this.previousMinorVersion = previousMinorVersion;
+	}
+
+	public int getPreviousBuildVersion() {
+		return previousBuildVersion;
+	}
+
+	public void setPreviousBuildVersion(int previousBuildVersion) {
+		this.previousBuildVersion = previousBuildVersion;
+	}
 
 	public int getType() {
 		return type;
@@ -17,5 +118,179 @@ public class Document {
 
 	public void setType(int type) {
 		this.type = type;
+	}
+
+	public short getPageHeight() {
+		return pageHeight;
+	}
+
+	public void setPageHeight(short pageHeight) {
+		this.pageHeight = pageHeight;
+	}
+
+	public short getPageWidth() {
+		return pageWidth;
+	}
+
+	public void setPageWidth(short pageWidth) {
+		this.pageWidth = pageWidth;
+	}
+
+	public short getInnerHeight() {
+		return innerHeight;
+	}
+
+	public void setInnerHeight(short innerHeight) {
+		this.innerHeight = innerHeight;
+	}
+
+	public short getInnerWidth() {
+		return innerWidth;
+	}
+
+	public void setInnerWidth(short innerWidth) {
+		this.innerWidth = innerWidth;
+	}
+
+	public short getMarginTop() {
+		return marginTop;
+	}
+
+	public void setMarginTop(short marginTop) {
+		this.marginTop = marginTop;
+	}
+
+	public short getMarginLeft() {
+		return marginLeft;
+	}
+
+	public void setMarginLeft(short marginLeft) {
+		this.marginLeft = marginLeft;
+	}
+
+	public short getMarginBottom() {
+		return marginBottom;
+	}
+
+	public void setMarginBottom(short marginBottom) {
+		this.marginBottom = marginBottom;
+	}
+
+	public short getMarginRight() {
+		return marginRight;
+	}
+
+	public void setMarginRight(short marginRight) {
+		this.marginRight = marginRight;
+	}
+
+	public short getMargin5() {
+		return margin5;
+	}
+
+	public void setMargin5(short margin5) {
+		this.margin5 = margin5;
+	}
+
+	public short getMargin6() {
+		return margin6;
+	}
+
+	public void setMargin6(short margin6) {
+		this.margin6 = margin6;
+	}
+
+	public List<String> getFonts() {
+		return fonts;
+	}
+
+	public void setFonts(List<String> fonts) {
+		this.fonts = fonts;
+	}
+
+	public void addFont(String font) {
+		this.fonts.add(font);
+	}
+
+	public List<StyleRun> getStyleRuns() {
+		return styleRuns;
+	}
+
+	public void setStyleRuns(List<StyleRun> styleRuns) {
+		this.styleRuns = styleRuns;
+	}
+
+	public void addStyleRun(StyleRun styleRun) {
+		this.styleRuns.add(styleRun);
+	}
+
+	public Map<String, Integer> getBlockIndex() {
+		return blockIndex;
+	}
+
+	public void setBlockIndex(Map<String, Integer> blockIndex) {
+		this.blockIndex = blockIndex;
+	}
+
+	public Integer getBlockOffset(String blockName) {
+		return blockIndex.get(blockName);
+	}
+
+	public byte[] getThumbnail() {
+		return thumbnail;
+	}
+
+	public void setThumbnail(byte[] thumbnail) {
+		this.thumbnail = thumbnail;
+	}
+
+	public String getContent() {
+		return content;
+	}
+
+	public void setContent(String content) {
+		this.content = content;
+	}
+
+	/**
+	 * Returns a human-readable document type name.
+	 */
+	public String getTypeName() {
+		switch (type) {
+			case TYPE_SPREADSHEET:
+			case TYPE_SPREADSHEET_V5:
+				return "Spreadsheet";
+			case TYPE_DRAWING:
+				return "Drawing";
+			case TYPE_TEXT:
+				return "Word Processing";
+			case TYPE_PAINTING:
+				return "Painting";
+			default:
+				return "Unknown (" + String.format("0x%04X", type) + ")";
+		}
+	}
+
+	/**
+	 * Returns true if the document was converted from an older version.
+	 */
+	public boolean wasConverted() {
+		return previousMajorVersion != majorVersion ||
+				previousMinorVersion != minorVersion ||
+				previousBuildVersion != buildVersion;
+	}
+
+	/**
+	 * Returns the version string (e.g., "6.7.225").
+	 */
+	public String getVersionString() {
+		return String.format("%d.%d.%d", majorVersion, minorVersion, buildVersion);
+	}
+
+	/**
+	 * Returns true if the document is in landscape orientation.
+	 */
+	public boolean isLandscape() {
+		return pageWidth > pageHeight;
 	}
 }

--- a/parser/src/main/java/com/wirelust/appleworks/Parser.java
+++ b/parser/src/main/java/com/wirelust/appleworks/Parser.java
@@ -4,13 +4,12 @@ import java.io.BufferedInputStream;
 import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -24,7 +23,6 @@ import org.odftoolkit.odfdom.doc.OdfTextDocument;
 import org.odftoolkit.odfdom.dom.element.style.StyleMasterPageElement;
 import org.odftoolkit.odfdom.dom.style.props.OdfPageLayoutProperties;
 import org.odftoolkit.odfdom.incubator.doc.office.OdfOfficeMasterStyles;
-import org.odftoolkit.odfdom.incubator.doc.office.OdfOfficeStyles;
 import org.odftoolkit.odfdom.incubator.doc.style.OdfStylePageLayout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,17 +32,48 @@ import org.slf4j.LoggerFactory;
  *
  * @author T. Curran
  *
- * Appleworks / clarisworks parser, as described here:
+ * AppleWorks / ClarisWorks parser, as described here:
  *
  * http://wiki.wirelust.com/x/index.php/AppleWorks_/_ClarisWorks#Document_Header
  *
+ * Supports versions 4.x, 5.x, and 6.x of ClarisWorks/AppleWorks files (.cwk)
  */
 public class Parser {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(Parser.class);
 
-	static final byte[] KEYWORD_DSET	= {0x44, 0x53, 0x45, 0x54};
+	// Block keyword constants
+	static final byte[] KEYWORD_DSET = {0x44, 0x53, 0x45, 0x54}; // DSET - Dataset
+	static final byte[] KEYWORD_ETBL = {0x45, 0x54, 0x42, 0x4C}; // ETBL - End Table (TOC)
+	static final byte[] KEYWORD_FNTM = {0x46, 0x4E, 0x54, 0x4D}; // FNTM - Font Map
+	static final byte[] KEYWORD_CHAR = {0x43, 0x48, 0x41, 0x52}; // CHAR - Character Styles
+	static final byte[] KEYWORD_STYL = {0x53, 0x54, 0x59, 0x4C}; // STYL - Styles
+	static final byte[] KEYWORD_SNAP = {0x53, 0x4E, 0x41, 0x50}; // SNAP - Snapshot/Thumbnail
+	static final byte[] KEYWORD_CPRT = {0x43, 0x50, 0x52, 0x54}; // CPRT - Print Settings
+	static final byte[] KEYWORD_DSUM = {0x44, 0x53, 0x55, 0x4D}; // DSUM - Document Summary
+	static final byte[] KEYWORD_HDNI = {0x48, 0x44, 0x4E, 0x49}; // HDNI - Header Info
+	static final byte[] KEYWORD_MCRO = {0x4D, 0x43, 0x52, 0x4F}; // MCRO - Macros
+	static final byte[] KEYWORD_MARK = {0x4D, 0x41, 0x52, 0x4B}; // MARK - Markers
+	static final byte[] KEYWORD_WMBT = {0x57, 0x4D, 0x42, 0x54}; // WMBT - Unknown
+	static final byte[] KEYWORD_TNAM = {0x54, 0x4E, 0x41, 0x4D}; // TNAM - Template Name
+	static final byte[] KEYWORD_CTAB = {0x43, 0x54, 0x41, 0x42}; // CTAB - Cell Table (spreadsheets)
 
+	// BOBO signature
+	static final byte[] SIGNATURE_BOBO = {0x42, 0x4F, 0x42, 0x4F};
+
+	// File end marker (always present at end of file)
+	static final byte[] FILE_END_MARKER = {
+		(byte) 0xFF, (byte) 0xFE, (byte) 0xFD, (byte) 0xFC,
+		(byte) 0xFB, (byte) 0xFA, (byte) 0xF9, (byte) 0xF8,
+		(byte) 0xF0, (byte) 0xF1, (byte) 0xF2, (byte) 0xF3,
+		(byte) 0xF4, (byte) 0xF5, (byte) 0xF6, (byte) 0xF7
+	};
+
+	// Document type position offset (corrected: at 0x80, not 268/278)
+	static final int DOCTYPE_OFFSET = 0x80;
+
+	// Font entry size in FNTM block
+	static final int FONT_ENTRY_SIZE = 0x45; // 69 bytes per font
 
 	private String opt_file;
 	private boolean opt_output = false;
@@ -53,11 +82,8 @@ public class Parser {
 	/**
 	 * @param args command line arguments
 	 */
-	public static void main(
-			String[] args) {
-
+	public static void main(String[] args) {
 		Parser app = new Parser();
-
 		CommandLine cl = app.getCommandLine(args);
 		app.processCommandLine(cl);
 		app.run();
@@ -65,7 +91,6 @@ public class Parser {
 
 	public void run() {
 		println("file=" + opt_file);
-
 
 		FileInputStream fileInputStream;
 		BufferedInputStream bufferedInputStream;
@@ -75,35 +100,14 @@ public class Parser {
 		FileInputStream fileInputStream2;
 		BufferedInputStream bufferedInputStream2 = null;
 
-		byte allBytes[] = null;
+		byte[] allBytes = null;
 
 		Charset macRomanCharset = Charset.forName("MacRoman");
 		Charset utf8Charset = Charset.forName("UTF-8");
 
-		// page height
-		short page_height = 792;
-
-		// page width
-		short page_width = 612;
-
-		// margins
-		short marginTop = 72;
-		short marginLeft = 72;
-		short marginBottom = 72;
-		short marginRight = 72;
-		short margin5 = 72;
-		short margin6 = 72;
-
-		// page height
-		short pageInnerHeight = 720;
-
-		// page width
-		short pageInnerWidth = 540;
-
 		Document doc = new Document();
 
 		try {
-
 			File file = new File(opt_file);
 
 			fileInputStream = new FileInputStream(file);
@@ -111,124 +115,117 @@ public class Parser {
 			countingInputStream = new CountingInputStream(bufferedInputStream);
 			dataInputStream = new DataInputStream(countingInputStream);
 
-			// version
-			// 06 07 E1 00
-			int version1 = dataInputStream.read();
-			int version2 = dataInputStream.read();
-			int version3 = dataInputStream.read();
-			dataInputStream.skipBytes(1);
-			println("version=%d.%d.%d", version1, version2, version3);
+			// Version bytes 0-3
+			// Format: [major] [minor] [build_high] [build_low]
+			int majorVersion = dataInputStream.read();
+			int minorVersion = dataInputStream.read();
+			int buildHigh = dataInputStream.read();
+			int buildLow = dataInputStream.read();
+			int buildVersion = (buildHigh << 8) | buildLow;
 
-			int typePosition = 0;
-			switch (version1) {
-				case 5:
-					typePosition = 268;
-					break;
-				case 6:
-					typePosition = 278;
-			}
+			doc.setMajorVersion(majorVersion);
+			doc.setMinorVersion(minorVersion);
+			doc.setBuildVersion(buildVersion);
 
-			// BOBO
-			// 42 4F 42 4F
+			println("version=%d.%d (build 0x%02X%02X)", majorVersion, minorVersion, buildHigh, buildLow);
+
+			// BOBO signature (bytes 4-7)
 			byte[] bobo = new byte[4];
 			dataInputStream.read(bobo);
 
-			if (bobo[0] != 0x42
-					|| bobo[1] != 0x4F
-					|| bobo[2] != 0x42
-					|| bobo[3] != 0x4F) {
+			if (!Arrays.equals(bobo, SIGNATURE_BOBO)) {
 				exit("file appears to be invalid. BOBO header not found");
 			}
 
-			// previous version
-			// 06 07 E1 00
-			int previousVersion1 = dataInputStream.read();
-			int previousVersion2 = dataInputStream.read();
-			int previousVersion3 = dataInputStream.read();
-			dataInputStream.skipBytes(1);
-			println("previous version=%d.%d.%d", previousVersion1, previousVersion2, previousVersion3);
+			// Previous version (bytes 8-11) - if file was converted
+			int prevMajorVersion = dataInputStream.read();
+			int prevMinorVersion = dataInputStream.read();
+			int prevBuildHigh = dataInputStream.read();
+			int prevBuildLow = dataInputStream.read();
+			int prevBuildVersion = (prevBuildHigh << 8) | prevBuildLow;
 
-			// unknown
-			// 00 00 00 00 00 00 00 00
-			dataInputStream.skipBytes(8);
+			doc.setPreviousMajorVersion(prevMajorVersion);
+			doc.setPreviousMinorVersion(prevMinorVersion);
+			doc.setPreviousBuildVersion(prevBuildVersion);
 
-			// unnknown
-			// 00 01
-			dataInputStream.skipBytes(2);
-
-			// unknown, possible marker
-			// 01 89
-			dataInputStream.skipBytes(2);
-
-			// unknown
-			// 1E EC
-			dataInputStream.skipBytes(2);
-
-			// unknown
-			// 00 00 00 00
-			dataInputStream.skipBytes(4);
-
-			// page height
-			page_height = dataInputStream.readShort();
-			println("page height=%d", page_height);
-
-			// page width
-			page_width = dataInputStream.readShort();
-			println("page width=%d", page_width);
-
-			// margins
-			// 00 48 00 48 00 48 00 48 00 48 00 48
-			marginTop = dataInputStream.readShort();
-			println("marginTop=%d", marginTop);
-
-			marginLeft = dataInputStream.readShort();
-			println("marginLeft=%d", marginLeft);
-
-			marginBottom = dataInputStream.readShort();
-			println("marginBottom=%d", marginBottom);
-
-			marginRight = dataInputStream.readShort();
-			println("marginRight=%d", marginRight);
-
-			margin5 = dataInputStream.readShort();
-			println("margin5=%d", margin5);
-
-			margin6 = dataInputStream.readShort();
-			println("margin6=%d", margin6);
-
-			// page height
-			pageInnerHeight = dataInputStream.readShort();
-			println("page inner height=%d", pageInnerHeight);
-
-			// page width
-			pageInnerWidth = dataInputStream.readShort();
-			println("page inner width=%d", pageInnerWidth);
-
-			// flags
-			short flag1 = dataInputStream.readShort();
-			short flag2 = dataInputStream.readShort();
-			short flag3 = dataInputStream.readShort();
-			short flag4 = dataInputStream.readShort();
-
-			if (typePosition > 0 && countingInputStream.getCount() < typePosition) {
-				dataInputStream.skipBytes(typePosition - countingInputStream.getCount());
+			if (doc.wasConverted()) {
+				println("previous version=%d.%d (build 0x%02X%02X) - file was converted",
+						prevMajorVersion, prevMinorVersion, prevBuildHigh, prevBuildLow);
 			}
 
-			doc.setType(dataInputStream.readByte());
+			// Unknown (bytes 12-19) - usually zeros
+			dataInputStream.skipBytes(8);
 
-			// this isn't really the end of the header. I just don't know where it ends yet.
-			int headerEndPosition = countingInputStream.getCount();
+			// Unknown (bytes 20-21) - usually 0x0001
+			dataInputStream.skipBytes(2);
 
+			// Marker (bytes 22-23)
+			dataInputStream.skipBytes(2);
 
-			// TODO: figure out a more efficient way to do this.
-			// for now, we are just reading the whole file into an array
-			// once we have more of the file format figured out we should be
-			// able to do it with a peek ahead input stream.
+			// Unknown (bytes 24-25)
+			dataInputStream.skipBytes(2);
 
+			// Unknown (bytes 26-29)
+			dataInputStream.skipBytes(4);
 
+			// Page height (bytes 30-31)
+			short pageHeight = dataInputStream.readShort();
+			doc.setPageHeight(pageHeight);
+			println("page height=%d pts (%.2f in)", pageHeight, pageHeight / 72.0);
+
+			// Page width (bytes 32-33)
+			short pageWidth = dataInputStream.readShort();
+			doc.setPageWidth(pageWidth);
+			println("page width=%d pts (%.2f in)", pageWidth, pageWidth / 72.0);
+
+			// Margins (bytes 34-45) - 6 x 2-byte values
+			short marginTop = dataInputStream.readShort();
+			short marginLeft = dataInputStream.readShort();
+			short marginBottom = dataInputStream.readShort();
+			short marginRight = dataInputStream.readShort();
+			short margin5 = dataInputStream.readShort();
+			short margin6 = dataInputStream.readShort();
+
+			doc.setMarginTop(marginTop);
+			doc.setMarginLeft(marginLeft);
+			doc.setMarginBottom(marginBottom);
+			doc.setMarginRight(marginRight);
+			doc.setMargin5(margin5);
+			doc.setMargin6(margin6);
+
+			println("margins: top=%d, left=%d, bottom=%d, right=%d, m5=%d, m6=%d",
+					marginTop, marginLeft, marginBottom, marginRight, margin5, margin6);
+
+			// Inner page height (bytes 46-47)
+			short innerHeight = dataInputStream.readShort();
+			doc.setInnerHeight(innerHeight);
+
+			// Inner page width (bytes 48-49)
+			short innerWidth = dataInputStream.readShort();
+			doc.setInnerWidth(innerWidth);
+
+			println("inner dimensions: %d x %d pts", innerWidth, innerHeight);
+
+			// Skip to document type position (0x80)
+			int currentPos = countingInputStream.getCount();
+			if (currentPos < DOCTYPE_OFFSET) {
+				dataInputStream.skipBytes(DOCTYPE_OFFSET - currentPos);
+			}
+
+			// Document type (2 bytes at offset 0x80)
+			short docType = dataInputStream.readShort();
+			doc.setType(docType);
+			println("document type=0x%04X (%s)", docType, doc.getTypeName());
+
+			if (doc.isLandscape()) {
+				println("orientation=landscape");
+			} else {
+				println("orientation=portrait");
+			}
+
+			// Read entire file for block parsing
 			fileInputStream2 = new FileInputStream(file);
 			bufferedInputStream2 = new BufferedInputStream(fileInputStream2);
-
 			allBytes = IOUtils.toByteArray(bufferedInputStream2);
 
 		} catch (IOException e) {
@@ -252,61 +249,79 @@ public class Parser {
 		}
 
 		if (allBytes != null && allBytes.length > 0) {
+
+			// Parse ETBL (End Table of Contents) for block index
+			Map<String, Integer> blockIndex = parseETBL(allBytes);
+			doc.setBlockIndex(blockIndex);
+			if (!blockIndex.isEmpty()) {
+				println("ETBL block index found with %d entries", blockIndex.size());
+				for (Map.Entry<String, Integer> entry : blockIndex.entrySet()) {
+					println("\t%s -> offset 0x%08X (%d)", entry.getKey(), entry.getValue(), entry.getValue());
+				}
+			}
+
+			// Parse FNTM (Font Map)
+			parseFonts(allBytes, doc);
+			if (!doc.getFonts().isEmpty()) {
+				println("Fonts found: %d", doc.getFonts().size());
+				for (int i = 0; i < doc.getFonts().size(); i++) {
+					println("\t[%d] %s", i, doc.getFonts().get(i));
+				}
+			}
+
+			// Parse content using DSET blocks
 			int content_start_position = 0;
 			int contentEndPosition = 0;
 			boolean content_start_found = false;
 
-			int dsetBlocks = 5; // all DSETs have beeen observed to have 5 blocks
+			int dsetBlocks = 5; // all DSETs have been observed to have 5 blocks
 			int dsetIndex = 0;
 			byte[] keyword = new byte[4];
-			for (int i=0; i<allBytes.length; i++) {
+
+			for (int i = 0; i < allBytes.length - 4; i++) {
 				keyword = Arrays.copyOfRange(allBytes, i, i + keyword.length);
 
 				int blockPosition = i + keyword.length;
 				if (Arrays.equals(keyword, KEYWORD_DSET)) {
-					println("DSET found at position:%d", i);
+					println("DSET found at position: 0x%08X (%d)", i, i);
 					dsetIndex++;
 
-					for (int blockIndex = 0; blockIndex < dsetBlocks; blockIndex++) {
+					for (int blockIndex2 = 0; blockIndex2 < dsetBlocks; blockIndex2++) {
 						int blockLen = getArrayInt(allBytes, blockPosition);
-						println("\tdset:%d, block:%d, length:%d", dsetIndex, blockIndex, blockLen);
-
+						println("\tdset:%d, block:%d, length:%d", dsetIndex, blockIndex2, blockLen);
 						blockPosition = blockPosition + 4 + blockLen;
 					}
 
 					if (dsetIndex == 1 && !content_start_found) {
 						content_start_found = true;
 						content_start_position = blockPosition;
-
 						processFirstDSet(allBytes, i + keyword.length);
 					}
 				}
-
 			}
-
 
 			OdfTextDocument convertedDoc = null;
 
 			if (opt_output) {
 				try {
 					convertedDoc = OdfTextDocument.newTextDocument();
-
 				} catch (Exception e) {
-					// OdfTextDocument really throws java.lang.Exception, really.
 					LOGGER.error("error creating output document");
 					opt_output = false;
 				}
 
 				if (convertedDoc != null) {
-					OdfOfficeMasterStyles masterStyles = convertedDoc.getOfficeMasterStyles(); 
+					OdfOfficeMasterStyles masterStyles = convertedDoc.getOfficeMasterStyles();
 					StyleMasterPageElement masterStyle = masterStyles.getMasterPage("Standard");
 					String layoutName = masterStyle.getStylePageLayoutNameAttribute();
 
 					OdfStylePageLayout layoutStyle = masterStyle.getAutomaticStyles().getPageLayout(layoutName);
-					layoutStyle.setProperty(OdfPageLayoutProperties.PageWidth, String.format("%dpt", page_width));
-					layoutStyle.setProperty(OdfPageLayoutProperties.PageHeight, String.format("%dpt", page_height));
-					
-					if (page_width > page_height) {
+					layoutStyle.setProperty(OdfPageLayoutProperties.PageWidth,
+							String.format("%dpt", doc.getPageWidth()));
+					layoutStyle.setProperty(OdfPageLayoutProperties.PageHeight,
+							String.format("%dpt", doc.getPageHeight()));
+
+					if (doc.isLandscape()) {
 						masterStyle.setProperty(OdfPageLayoutProperties.PrintOrientation, "landscape");
 					} else {
 						masterStyle.setProperty(OdfPageLayoutProperties.PrintOrientation, "portrait");
@@ -315,35 +330,40 @@ public class Parser {
 			}
 
 			if (content_start_found) {
-				println("content starts at position=%d", content_start_position);
+				println("content starts at position=0x%08X (%d)", content_start_position, content_start_position);
 
+				StringBuilder contentBuilder = new StringBuilder();
 				boolean contentEndFound = false;
 				int blockPosition = content_start_position;
 				int contentBlockIndex = 0;
-				while (!contentEndFound) {
+
+				while (!contentEndFound && blockPosition < allBytes.length - 4) {
 					int blockLen = getArrayInt(allBytes, blockPosition);
 
-					String block = new String(Arrays.copyOfRange(allBytes, blockPosition + 4, blockPosition + 4 + blockLen), macRomanCharset);
+					if (blockLen <= 0 || blockLen > allBytes.length - blockPosition - 4) {
+						break;
+					}
 
-					if (block.charAt(block.length()-1) == 0x00) {
+					String block = new String(
+							Arrays.copyOfRange(allBytes, blockPosition + 4, blockPosition + 4 + blockLen),
+							macRomanCharset);
+
+					if (block.length() > 0 && block.charAt(block.length() - 1) == 0x00) {
 						contentEndFound = true;
 						contentEndPosition = blockPosition;
-
-						// we don't want that last null character.
 						block = block.substring(0, block.length() - 1);
 					}
 
 					println("\tcontent block:%d, length:%d", contentBlockIndex, blockLen);
 
-					// TODO: I don't think this properly converts MacRoman to UTF8
 					String blockUtf8 = new String(block.getBytes(utf8Charset)).replaceAll("\r", "\n");
+					contentBuilder.append(blockUtf8);
 
 					if (opt_print_content) {
 						System.out.println(blockUtf8);
 					}
 
-					if (opt_output) {
-						// add the text to the convert document
+					if (opt_output && convertedDoc != null) {
 						try {
 							convertedDoc.addText(blockUtf8);
 						} catch (Exception e) {
@@ -351,38 +371,148 @@ public class Parser {
 						}
 					}
 
-
 					blockPosition = blockPosition + 4 + blockLen;
 					contentBlockIndex++;
-
 				}
 
-				println("content ends at position=%d", contentEndPosition);
+				doc.setContent(contentBuilder.toString());
+				println("content ends at position=0x%08X (%d)", contentEndPosition, contentEndPosition);
 
-				if (opt_output) {
+				if (opt_output && convertedDoc != null) {
 					String convertedFileName = opt_file.replace(".cwk", ".odt");
 
 					if (new File(convertedFileName).exists()) {
 						LOGGER.error("unable to save converted document. '{}' exists.", convertedFileName);
 					} else {
-						// Save converted document
 						try {
 							convertedDoc.save(convertedFileName);
 							convertedDoc.close();
+							println("Saved converted document: %s", convertedFileName);
 						} catch (Exception e) {
 							LOGGER.error("error saving converted document", e);
 						}
 					}
 				}
 			}
+
+			// Verify file end marker
+			int endMarkerPos = findPattern(allBytes, FILE_END_MARKER, allBytes.length - 100);
+			if (endMarkerPos > 0) {
+				println("File end marker found at: 0x%08X (%d)", endMarkerPos, endMarkerPos);
+			}
 		}
 	}
 
-	public void processFirstDSet(byte allBytes[], int startPosition) {
+	/**
+	 * Parses the ETBL block to build an index of all blocks and their offsets.
+	 * The ETBL block is located near the end of the file and contains a table of contents.
+	 *
+	 * Format:
+	 *   ETBL (4 bytes)
+	 *   Total size (4 bytes, big-endian)
+	 *   Entries:
+	 *     Block name (4 bytes, ASCII)
+	 *     Block offset (4 bytes, big-endian)
+	 *     ... repeating ...
+	 */
+	public Map<String, Integer> parseETBL(byte[] allBytes) {
+		Map<String, Integer> blockIndex = new HashMap<>();
+
+		// Find the last occurrence of ETBL (the TOC is near the end)
+		int etblPos = findLastPattern(allBytes, KEYWORD_ETBL);
+
+		if (etblPos < 0) {
+			return blockIndex;
+		}
+
+		println("Parsing ETBL at position: 0x%08X", etblPos);
+
+		int size = getArrayInt(allBytes, etblPos + 4);
+		println("ETBL size: %d bytes", size);
+
+		int pos = etblPos + 8;
+		int endPos = etblPos + 4 + size;
+
+		while (pos + 8 <= endPos && pos + 8 < allBytes.length) {
+			String blockName = new String(Arrays.copyOfRange(allBytes, pos, pos + 4),
+					Charset.forName("US-ASCII"));
+			int offset = getArrayInt(allBytes, pos + 4);
+
+			// Stop if we hit the file end marker or invalid data
+			if (blockName.charAt(0) == (char) 0xFF) {
+				break;
+			}
+
+			blockIndex.put(blockName, offset);
+			pos += 8;
+		}
+
+		return blockIndex;
+	}
+
+	/**
+	 * Parses the FNTM (Font Map) block to extract font names.
+	 *
+	 * Format:
+	 *   FNTM (4 bytes)
+	 *   ... header bytes ...
+	 *   For each font (69 bytes each):
+	 *     Header (2 bytes)
+	 *     Index (2 bytes)
+	 *     Name length (1 byte)
+	 *     Font name (null-padded to fill remaining bytes)
+	 */
+	public void parseFonts(byte[] allBytes, Document doc) {
+		int fntmPos = findPattern(allBytes, KEYWORD_FNTM, 0);
+
+		if (fntmPos < 0) {
+			return;
+		}
+
+		println("Parsing FNTM at position: 0x%08X", fntmPos);
+
+		// Skip to font entries (after FNTM keyword and some header bytes)
+		int pos = fntmPos + 4;
+
+		// Read block size
+		int blockSize = getArrayInt(allBytes, pos);
+		pos += 4;
+
+		// Skip header bytes (observed pattern: 0x0015 0x0002 before first font)
+		// Look for font entry pattern
+		while (pos < fntmPos + 4 + blockSize && pos + FONT_ENTRY_SIZE < allBytes.length) {
+			// Check for font entry header pattern (0x00 0x15 observed)
+			if (allBytes[pos] == 0x00 && allBytes[pos + 1] == 0x15) {
+				// Skip header (2 bytes) and index (2 bytes)
+				pos += 4;
+
+				// Read font name length
+				int nameLen = allBytes[pos] & 0xFF;
+				pos++;
+
+				if (nameLen > 0 && nameLen < 64 && pos + nameLen <= allBytes.length) {
+					String fontName = new String(Arrays.copyOfRange(allBytes, pos, pos + nameLen),
+							Charset.forName("MacRoman")).trim();
+					if (!fontName.isEmpty() && fontName.matches("[\\x20-\\x7E]+")) {
+						doc.addFont(fontName);
+					}
+				}
+
+				// Skip to next entry (remainder of 69-byte entry minus what we've read)
+				pos += (FONT_ENTRY_SIZE - 5);
+			} else {
+				pos++;
+			}
+		}
+	}
+
+	/**
+	 * Process the first DSET block to understand content structure.
+	 */
+	public void processFirstDSet(byte[] allBytes, int startPosition) {
 		println("First DSET block");
 
 		int position = startPosition;
-
 		boolean dsetDone = false;
 
 		while (!dsetDone) {
@@ -394,24 +524,71 @@ public class Parser {
 			position = position + 2;
 			println("\tblock count:%d", blockCount);
 
-			for (int i=0; i<blockCount; i++) {
+			for (int i = 0; i < blockCount; i++) {
 				position = position + 30;
 			}
-			println("\tblocks end at:%d", position);
+			println("\tblocks end at: 0x%08X (%d)", position, position);
 
 			dsetDone = true;
 		}
-
-
-
 	}
 
+	/**
+	 * Find pattern in byte array starting from given position.
+	 */
+	public int findPattern(byte[] allBytes, byte[] pattern, int startPos) {
+		for (int i = startPos; i <= allBytes.length - pattern.length; i++) {
+			boolean found = true;
+			for (int j = 0; j < pattern.length; j++) {
+				if (allBytes[i + j] != pattern[j]) {
+					found = false;
+					break;
+				}
+			}
+			if (found) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	/**
+	 * Find the last occurrence of pattern in byte array.
+	 */
+	public int findLastPattern(byte[] allBytes, byte[] pattern) {
+		for (int i = allBytes.length - pattern.length; i >= 0; i--) {
+			boolean found = true;
+			for (int j = 0; j < pattern.length; j++) {
+				if (allBytes[i + j] != pattern[j]) {
+					found = false;
+					break;
+				}
+			}
+			if (found) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	/**
+	 * Read a 4-byte big-endian integer from byte array.
+	 */
 	public int getArrayInt(byte[] array, int position) {
+		if (position + 4 > array.length) {
+			return 0;
+		}
 		ByteBuffer wrapped = ByteBuffer.wrap(Arrays.copyOfRange(array, position, position + 4));
 		return wrapped.getInt();
 	}
 
+	/**
+	 * Read a 2-byte big-endian short from byte array.
+	 */
 	public short getArrayShort(byte[] array, int position) {
+		if (position + 2 > array.length) {
+			return 0;
+		}
 		ByteBuffer wrapped = ByteBuffer.wrap(Arrays.copyOfRange(array, position, position + 2));
 		return wrapped.getShort();
 	}
@@ -422,21 +599,14 @@ public class Parser {
 
 	/**
 	 * Converts a main(String[] args) array into a parsed CommandLine
-	 *
-	 * @param args args from supplied to the main method
-	 * @return Parsed CommandLine object
 	 */
 	private CommandLine getCommandLine(String[] args) {
-
 		CommandLine line = null;
-		// create the command line parser
 		CommandLineParser parser = new GnuParser();
 		Options options = getOptions();
 		try {
-			// parse the command line arguments
 			line = parser.parse(options, args);
 		} catch (ParseException e) {
-			// oops, something went wrong
 			exitWithUsage("Invalid args encountered:" + e.getMessage());
 		}
 		return line;
@@ -444,26 +614,19 @@ public class Parser {
 
 	/**
 	 * Gets command line options for the application
-	 *
-	 * @return Options for the application
 	 */
 	public Options getOptions() {
-
 		Options options = new Options();
 		options.addOption("f", "file", true, "file to parse");
 		options.addOption("o", "output", false, "output converted document");
 		options.addOption("p", "print-content", false, "print content");
-
 		return options;
 	}
 
 	/**
-	 * reads settings from command line
-	 *
-	 * @param cl commandLine instance
+	 * Reads settings from command line
 	 */
 	private void processCommandLine(CommandLine cl) {
-
 		if (cl.hasOption("f")) {
 			opt_file = cl.getOptionValue("f");
 		}
@@ -479,28 +642,20 @@ public class Parser {
 		if (opt_file == null || opt_file.isEmpty()) {
 			exitWithUsage("You must specify a file to parse");
 		}
-
-
 	}
 
 	/**
 	 * Exits the application with a message in the log
-	 *
-	 * @param msg to be printed to the log right before System.exit
 	 */
 	private void exit(String msg) {
-
 		LOGGER.info(msg);
 		System.exit(1);
 	}
 
 	/**
-	 * Exits the application with a message in the log and prints the usage to the stdout
-	 *
-	 * @param msg to be printed to the log
+	 * Exits the application with a message in the log and prints the usage to stdout
 	 */
 	private void exitWithUsage(String msg) {
-
 		LOGGER.info(msg);
 		usage();
 		System.exit(1);
@@ -510,10 +665,7 @@ public class Parser {
 	 * Formats and prints the command line options to stdout
 	 */
 	private void usage() {
-
-		// automatically generate the usage statement
 		HelpFormatter formatter = new HelpFormatter();
 		formatter.printHelp("parse.sh", getOptions());
 	}
-
 }

--- a/parser/src/main/java/com/wirelust/appleworks/StyleRun.java
+++ b/parser/src/main/java/com/wirelust/appleworks/StyleRun.java
@@ -1,0 +1,154 @@
+package com.wirelust.appleworks;
+
+/**
+ * Represents a style run within a ClarisWorks/AppleWorks document.
+ *
+ * A style run defines the formatting applied to a range of text.
+ * Style runs are parsed from the CHAR block within the document.
+ *
+ * The CHAR block contains entries approximately 20 bytes each:
+ * - Bytes 0-1: Style flags
+ * - Bytes 2-5: Unknown (usually 0x00000000)
+ * - Bytes 6-7: Unknown (0x0300 observed)
+ * - Bytes 8-9: Unknown (often 0xFFFF)
+ * - Bytes 10-11: Unknown
+ * - Bytes 12-13: Text length for this run
+ * - Bytes 14-15: Character offset (cumulative position in text)
+ */
+public class StyleRun {
+
+	// Style flag constants (observed values, may be incomplete)
+	public static final int FLAG_NORMAL = 0x0C01;
+	public static final int FLAG_BOLD = 0x0901;
+	public static final int FLAG_ITALIC = 0x0E01;
+	public static final int FLAG_UNDERLINE = 0x0A01;
+
+	private int startOffset;
+	private int endOffset;
+	private int styleFlags;
+	private boolean bold;
+	private boolean italic;
+	private boolean underline;
+	private int fontIndex;
+	private int fontSize;
+
+	public StyleRun() {
+	}
+
+	public StyleRun(int startOffset, int endOffset, int styleFlags) {
+		this.startOffset = startOffset;
+		this.endOffset = endOffset;
+		this.styleFlags = styleFlags;
+		parseStyleFlags(styleFlags);
+	}
+
+	/**
+	 * Parses the style flags to set individual style attributes.
+	 * Note: This is based on observed patterns and may not be complete.
+	 */
+	private void parseStyleFlags(int flags) {
+		// These interpretations are based on observed patterns
+		// and may need refinement as more samples are analyzed
+		switch (flags) {
+			case FLAG_BOLD:
+				this.bold = true;
+				break;
+			case FLAG_ITALIC:
+				this.italic = true;
+				break;
+			case FLAG_UNDERLINE:
+				this.underline = true;
+				break;
+			default:
+				// Normal or unknown style
+				break;
+		}
+	}
+
+	public int getStartOffset() {
+		return startOffset;
+	}
+
+	public void setStartOffset(int startOffset) {
+		this.startOffset = startOffset;
+	}
+
+	public int getEndOffset() {
+		return endOffset;
+	}
+
+	public void setEndOffset(int endOffset) {
+		this.endOffset = endOffset;
+	}
+
+	public int getStyleFlags() {
+		return styleFlags;
+	}
+
+	public void setStyleFlags(int styleFlags) {
+		this.styleFlags = styleFlags;
+		parseStyleFlags(styleFlags);
+	}
+
+	public boolean isBold() {
+		return bold;
+	}
+
+	public void setBold(boolean bold) {
+		this.bold = bold;
+	}
+
+	public boolean isItalic() {
+		return italic;
+	}
+
+	public void setItalic(boolean italic) {
+		this.italic = italic;
+	}
+
+	public boolean isUnderline() {
+		return underline;
+	}
+
+	public void setUnderline(boolean underline) {
+		this.underline = underline;
+	}
+
+	public int getFontIndex() {
+		return fontIndex;
+	}
+
+	public void setFontIndex(int fontIndex) {
+		this.fontIndex = fontIndex;
+	}
+
+	public int getFontSize() {
+		return fontSize;
+	}
+
+	public void setFontSize(int fontSize) {
+		this.fontSize = fontSize;
+	}
+
+	/**
+	 * Returns the length of this style run in characters.
+	 */
+	public int getLength() {
+		return endOffset - startOffset;
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+		sb.append("StyleRun[");
+		sb.append(startOffset).append("-").append(endOffset);
+		sb.append(", flags=0x").append(String.format("%04X", styleFlags));
+		if (bold) sb.append(", BOLD");
+		if (italic) sb.append(", ITALIC");
+		if (underline) sb.append(", UNDERLINE");
+		if (fontIndex > 0) sb.append(", font=").append(fontIndex);
+		if (fontSize > 0) sb.append(", size=").append(fontSize);
+		sb.append("]");
+		return sb.toString();
+	}
+}


### PR DESCRIPTION
enhancements

- Fix document type detection to use correct offset 0x80 (was 268/278)
- Add document type constants: Text (0x0202), Drawing (0x0101), Painting (0x1515), Spreadsheet (0x0303)
- Add ETBL block parsing for table of contents / block index
- Add FNTM block parsing for font extraction
- Add StyleRun class for text formatting (bold, italic, underline)
- Enhance Document class with version, margins, fonts, and content fields
- Add new documentation: document_types, etbl, fonts, style_runs
- Update header.adoc with corrected positions and paper sizes
- Update keywords.adoc with hex values and descriptions
- Update index.adoc with capabilities and supported versions