### PR TITLE
Add ODF output support and batch conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,9 @@
 
 .idea/libraries/*
 
-.test_files/*.odt
+# Test output
+test_files/*.odt
+test_files_output/
+
+# Build output
+parser/target/

--- a/convert_all.sh
+++ b/convert_all.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Convert all CWK test files to ODT format
+#
+# Usage: ./convert_all.sh
+#
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INPUT_DIR="$SCRIPT_DIR/test_files"
+OUTPUT_DIR="$SCRIPT_DIR/test_files_output"
+PARSER_DIR="$SCRIPT_DIR/parser"
+
+# Build the parser first
+echo "Building parser..."
+cd "$PARSER_DIR"
+mvn compile -q
+if [ $? -ne 0 ]; then
+    echo "Build failed"
+    exit 1
+fi
+echo "Build successful"
+echo ""
+
+# Run the batch converter
+mvn exec:java -Dexec.mainClass="com.wirelust.appleworks.BatchConverter" \
+    -Dexec.args="\"$INPUT_DIR\" \"$OUTPUT_DIR\"" -q

--- a/parser/pom.xml
+++ b/parser/pom.xml
@@ -12,7 +12,7 @@
 		<dependency>
 			<groupId>org.odftoolkit</groupId>
 			<artifactId>odfdom-java</artifactId>
-			<version>0.8.7</version>
+			<version>0.12.0</version>
 		</dependency>
 
 		<dependency>

--- a/parser/src/main/java/com/wirelust/appleworks/BatchConverter.java
+++ b/parser/src/main/java/com/wirelust/appleworks/BatchConverter.java
@@ -1,0 +1,100 @@
+package com.wirelust.appleworks;
+
+import java.io.File;
+import java.io.FilenameFilter;
+
+/**
+ * Batch converter for AppleWorks files.
+ * Converts all CWK files in an input directory to ODT format in an output directory.
+ *
+ * Usage: java BatchConverter <input_dir> <output_dir>
+ */
+public class BatchConverter {
+
+	public static void main(String[] args) {
+		if (args.length < 2) {
+			System.out.println("Usage: BatchConverter <input_dir> <output_dir>");
+			System.out.println("  Converts all .cwk files in input_dir to .odt files in output_dir");
+			System.exit(1);
+		}
+
+		String inputDir = args[0];
+		String outputDir = args[1];
+
+		File inputFolder = new File(inputDir);
+		File outputFolder = new File(outputDir);
+
+		if (!inputFolder.exists() || !inputFolder.isDirectory()) {
+			System.err.println("Input directory does not exist: " + inputDir);
+			System.exit(1);
+		}
+
+		if (!outputFolder.exists()) {
+			outputFolder.mkdirs();
+		}
+
+		// Find all CWK files
+		File[] cwkFiles = inputFolder.listFiles(new FilenameFilter() {
+			@Override
+			public boolean accept(File dir, String name) {
+				return name.toLowerCase().endsWith(".cwk");
+			}
+		});
+
+		if (cwkFiles == null || cwkFiles.length == 0) {
+			System.out.println("No .cwk files found in: " + inputDir);
+			System.exit(0);
+		}
+
+		System.out.println("Converting " + cwkFiles.length + " CWK files...");
+		System.out.println("========================================");
+
+		Parser parser = new Parser();
+		OdfWriter writer = new OdfWriter();
+
+		int success = 0;
+		int failed = 0;
+
+		for (int i = 0; i < cwkFiles.length; i++) {
+			File cwkFile = cwkFiles[i];
+			String baseName = cwkFile.getName().replaceAll("\\.[cC][wW][kK]$", "");
+			File odtFile = new File(outputFolder, baseName + ".odt");
+
+			System.out.printf("[%3d/%3d] %-50s ", i + 1, cwkFiles.length, cwkFile.getName());
+
+			try {
+				Document doc = parser.parse(cwkFile.getAbsolutePath());
+
+				if (doc != null && doc.getContent() != null) {
+					// Delete existing output file if present
+					if (odtFile.exists()) {
+						odtFile.delete();
+					}
+
+					boolean written = writer.write(doc, odtFile.getAbsolutePath());
+					if (written) {
+						System.out.println("\u001B[32mOK\u001B[0m");
+						success++;
+					} else {
+						System.out.println("\u001B[31mFAILED (write)\u001B[0m");
+						failed++;
+					}
+				} else {
+					System.out.println("\u001B[33mSKIPPED (no content)\u001B[0m");
+					failed++;
+				}
+			} catch (Exception e) {
+				System.out.println("\u001B[31mFAILED (" + e.getMessage() + ")\u001B[0m");
+				failed++;
+			}
+		}
+
+		System.out.println("========================================");
+		System.out.println();
+		System.out.println("Conversion complete:");
+		System.out.println("  \u001B[32mSuccess: " + success + "\u001B[0m");
+		System.out.println("  \u001B[31mFailed:  " + failed + "\u001B[0m");
+		System.out.println();
+		System.out.println("Output files are in: " + outputFolder.getAbsolutePath());
+	}
+}

--- a/parser/src/main/java/com/wirelust/appleworks/OdfWriter.java
+++ b/parser/src/main/java/com/wirelust/appleworks/OdfWriter.java
@@ -1,0 +1,237 @@
+package com.wirelust.appleworks;
+
+import java.io.File;
+
+import org.odftoolkit.odfdom.doc.OdfTextDocument;
+import org.odftoolkit.odfdom.dom.element.style.StyleMasterPageElement;
+import org.odftoolkit.odfdom.dom.element.text.TextPElement;
+import org.odftoolkit.odfdom.dom.element.text.TextSpanElement;
+import org.odftoolkit.odfdom.dom.style.OdfStyleFamily;
+import org.odftoolkit.odfdom.dom.style.props.OdfPageLayoutProperties;
+import org.odftoolkit.odfdom.dom.style.props.OdfTextProperties;
+import org.odftoolkit.odfdom.incubator.doc.office.OdfOfficeMasterStyles;
+import org.odftoolkit.odfdom.incubator.doc.office.OdfOfficeStyles;
+import org.odftoolkit.odfdom.incubator.doc.style.OdfStyle;
+import org.odftoolkit.odfdom.incubator.doc.style.OdfStylePageLayout;
+import org.odftoolkit.odfdom.incubator.doc.text.OdfTextParagraph;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Writes AppleWorks Document objects to ODF (Open Document Format) files.
+ *
+ * ODF files can then be converted to other formats (PDF, DOCX, HTML) using
+ * LibreOffice headless mode:
+ *   soffice --headless --convert-to pdf document.odt
+ *   soffice --headless --convert-to docx document.odt
+ */
+public class OdfWriter {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(OdfWriter.class);
+
+	// Points per inch (ODF uses inches/cm, AppleWorks uses points)
+	private static final double POINTS_PER_INCH = 72.0;
+
+	/**
+	 * Converts an AppleWorks Document to ODF format and saves it.
+	 *
+	 * @param doc The parsed AppleWorks document
+	 * @param outputPath Path for the output .odt file
+	 * @return true if successful, false otherwise
+	 */
+	public boolean write(Document doc, String outputPath) {
+		if (doc == null) {
+			LOGGER.error("Document is null");
+			return false;
+		}
+
+		if (doc.getType() != Document.TYPE_TEXT) {
+			LOGGER.warn("Document type {} ({}) may not convert properly to ODF text document",
+					doc.getTypeName(), String.format("0x%04X", doc.getType()));
+		}
+
+		try {
+			OdfTextDocument odfDoc = OdfTextDocument.newTextDocument();
+
+			// Set page layout (dimensions and margins)
+			setupPageLayout(odfDoc, doc);
+
+			// Create font styles if fonts are available
+			setupFontStyles(odfDoc, doc);
+
+			// Add content with style runs
+			addContent(odfDoc, doc);
+
+			// Save the document
+			File outputFile = new File(outputPath);
+			if (outputFile.exists()) {
+				LOGGER.error("Output file already exists: {}", outputPath);
+				odfDoc.close();
+				return false;
+			}
+
+			odfDoc.save(outputPath);
+			odfDoc.close();
+
+			LOGGER.info("Successfully wrote ODF document: {}", outputPath);
+			return true;
+
+		} catch (Exception e) {
+			LOGGER.error("Error writing ODF document", e);
+			return false;
+		}
+	}
+
+	/**
+	 * Sets up page layout including dimensions, margins, and orientation.
+	 */
+	private void setupPageLayout(OdfTextDocument odfDoc, Document doc) throws Exception {
+		OdfOfficeMasterStyles masterStyles = odfDoc.getOfficeMasterStyles();
+		StyleMasterPageElement masterStyle = masterStyles.getMasterPage("Standard");
+
+		if (masterStyle == null) {
+			LOGGER.warn("Could not find Standard master page style");
+			return;
+		}
+
+		String layoutName = masterStyle.getStylePageLayoutNameAttribute();
+		OdfStylePageLayout layoutStyle = masterStyle.getAutomaticStyles().getPageLayout(layoutName);
+
+		if (layoutStyle == null) {
+			LOGGER.warn("Could not find page layout: {}", layoutName);
+			return;
+		}
+
+		// Set page dimensions (convert points to inches for ODF)
+		if (doc.getPageWidth() > 0) {
+			layoutStyle.setProperty(OdfPageLayoutProperties.PageWidth,
+					String.format("%.4fin", doc.getPageWidth() / POINTS_PER_INCH));
+		}
+
+		if (doc.getPageHeight() > 0) {
+			layoutStyle.setProperty(OdfPageLayoutProperties.PageHeight,
+					String.format("%.4fin", doc.getPageHeight() / POINTS_PER_INCH));
+		}
+
+		// Set margins (convert points to inches)
+		if (doc.getMarginTop() > 0) {
+			layoutStyle.setProperty(OdfPageLayoutProperties.MarginTop,
+					String.format("%.4fin", doc.getMarginTop() / POINTS_PER_INCH));
+		}
+
+		if (doc.getMarginBottom() > 0) {
+			layoutStyle.setProperty(OdfPageLayoutProperties.MarginBottom,
+					String.format("%.4fin", doc.getMarginBottom() / POINTS_PER_INCH));
+		}
+
+		if (doc.getMarginLeft() > 0) {
+			layoutStyle.setProperty(OdfPageLayoutProperties.MarginLeft,
+					String.format("%.4fin", doc.getMarginLeft() / POINTS_PER_INCH));
+		}
+
+		if (doc.getMarginRight() > 0) {
+			layoutStyle.setProperty(OdfPageLayoutProperties.MarginRight,
+					String.format("%.4fin", doc.getMarginRight() / POINTS_PER_INCH));
+		}
+
+		// Set orientation
+		if (doc.isLandscape()) {
+			layoutStyle.setProperty(OdfPageLayoutProperties.PrintOrientation, "landscape");
+		} else {
+			layoutStyle.setProperty(OdfPageLayoutProperties.PrintOrientation, "portrait");
+		}
+	}
+
+	/**
+	 * Creates ODF styles for fonts found in the AppleWorks document.
+	 */
+	private void setupFontStyles(OdfTextDocument odfDoc, Document doc) throws Exception {
+		if (doc.getFonts().isEmpty()) {
+			return;
+		}
+
+		OdfOfficeStyles styles = odfDoc.getOrCreateDocumentStyles();
+
+		for (int i = 0; i < doc.getFonts().size(); i++) {
+			String fontName = doc.getFonts().get(i);
+			String styleName = "Font" + i;
+
+			OdfStyle fontStyle = styles.newStyle(styleName, OdfStyleFamily.Text);
+			fontStyle.setProperty(OdfTextProperties.FontName, fontName);
+		}
+	}
+
+	/**
+	 * Adds document content to the ODF document, applying style runs if available.
+	 */
+	private void addContent(OdfTextDocument odfDoc, Document doc) throws Exception {
+		String content = doc.getContent();
+		if (content == null || content.isEmpty()) {
+			LOGGER.warn("Document has no content");
+			return;
+		}
+
+		// Split content into paragraphs (AppleWorks uses \r or \n for line breaks)
+		String[] paragraphs = content.split("[\r\n]+");
+
+		for (String paragraphText : paragraphs) {
+			if (paragraphText.isEmpty()) {
+				continue;
+			}
+
+			// Check if we have style runs to apply
+			if (!doc.getStyleRuns().isEmpty()) {
+				addStyledParagraph(odfDoc, doc, paragraphText);
+			} else {
+				// Simple text without styling
+				OdfTextParagraph paragraph = odfDoc.newParagraph();
+				paragraph.addContent(paragraphText);
+			}
+		}
+	}
+
+	/**
+	 * Adds a paragraph with style runs applied.
+	 * Note: Style run parsing is still experimental and may not work correctly.
+	 */
+	private void addStyledParagraph(OdfTextDocument odfDoc, Document doc, String text) throws Exception {
+		OdfTextParagraph paragraph = odfDoc.newParagraph();
+
+		// For now, just add plain text
+		// TODO: Implement proper style run application once CHAR block parsing is complete
+		paragraph.addContent(text);
+
+		// Future implementation would iterate through style runs and create spans:
+		// for (StyleRun run : doc.getStyleRuns()) {
+		//     if (run overlaps with this paragraph) {
+		//         TextSpanElement span = paragraph.newTextSpanElement();
+		//         span.setStyleName(getStyleForRun(run));
+		//         span.setTextContent(substring);
+		//     }
+		// }
+	}
+
+	/**
+	 * Convenience method to convert a CWK file to ODF.
+	 *
+	 * @param cwkPath Path to the input .cwk file
+	 * @param odfPath Path for the output .odt file (optional, defaults to same name with .odt extension)
+	 * @return true if successful
+	 */
+	public static boolean convert(String cwkPath, String odfPath) {
+		if (odfPath == null || odfPath.isEmpty()) {
+			odfPath = cwkPath.replaceAll("\\.[cC][wW][kK]$", ".odt");
+		}
+
+		// TODO: Integrate with Parser to parse and write in one step
+		LOGGER.info("Converting {} to {}", cwkPath, odfPath);
+
+		// This would be called after parsing:
+		// Parser parser = new Parser();
+		// Document doc = parser.parse(cwkPath);
+		// OdfWriter writer = new OdfWriter();
+		// return writer.write(doc, odfPath);
+
+		return false;
+	}
+}

--- a/parser/src/main/java/com/wirelust/appleworks/Parser.java
+++ b/parser/src/main/java/com/wirelust/appleworks/Parser.java
@@ -19,11 +19,6 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.CountingInputStream;
-import org.odftoolkit.odfdom.doc.OdfTextDocument;
-import org.odftoolkit.odfdom.dom.element.style.StyleMasterPageElement;
-import org.odftoolkit.odfdom.dom.style.props.OdfPageLayoutProperties;
-import org.odftoolkit.odfdom.incubator.doc.office.OdfOfficeMasterStyles;
-import org.odftoolkit.odfdom.incubator.doc.style.OdfStylePageLayout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,6 +73,7 @@ public class Parser {
 	private String opt_file;
 	private boolean opt_output = false;
 	private boolean opt_print_content = false;
+	private boolean opt_verbose = true;
 
 	/**
 	 * @param args command line arguments
@@ -89,8 +85,31 @@ public class Parser {
 		app.run();
 	}
 
+	/**
+	 * Parses an AppleWorks/ClarisWorks file and returns a Document object.
+	 *
+	 * @param filePath Path to the .cwk file
+	 * @return Parsed Document object, or null if parsing failed
+	 */
+	public Document parse(String filePath) {
+		this.opt_file = filePath;
+		this.opt_verbose = false;
+		return parseInternal();
+	}
+
 	public void run() {
-		println("file=" + opt_file);
+		Document doc = parseInternal();
+		if (doc != null && opt_output) {
+			String outputPath = opt_file.replaceAll("\\.[cC][wW][kK]$", ".odt");
+			OdfWriter writer = new OdfWriter();
+			writer.write(doc, outputPath);
+		}
+	}
+
+	private Document parseInternal() {
+		if (opt_verbose) {
+			println("file=" + opt_file);
+		}
 
 		FileInputStream fileInputStream;
 		BufferedInputStream bufferedInputStream;
@@ -300,35 +319,6 @@ public class Parser {
 				}
 			}
 
-			OdfTextDocument convertedDoc = null;
-
-			if (opt_output) {
-				try {
-					convertedDoc = OdfTextDocument.newTextDocument();
-				} catch (Exception e) {
-					LOGGER.error("error creating output document");
-					opt_output = false;
-				}
-
-				if (convertedDoc != null) {
-					OdfOfficeMasterStyles masterStyles = convertedDoc.getOfficeMasterStyles();
-					StyleMasterPageElement masterStyle = masterStyles.getMasterPage("Standard");
-					String layoutName = masterStyle.getStylePageLayoutNameAttribute();
-
-					OdfStylePageLayout layoutStyle = masterStyle.getAutomaticStyles().getPageLayout(layoutName);
-					layoutStyle.setProperty(OdfPageLayoutProperties.PageWidth,
-							String.format("%dpt", doc.getPageWidth()));
-					layoutStyle.setProperty(OdfPageLayoutProperties.PageHeight,
-							String.format("%dpt", doc.getPageHeight()));
-
-					if (doc.isLandscape()) {
-						masterStyle.setProperty(OdfPageLayoutProperties.PrintOrientation, "landscape");
-					} else {
-						masterStyle.setProperty(OdfPageLayoutProperties.PrintOrientation, "portrait");
-					}
-				}
-			}
-
 			if (content_start_found) {
 				println("content starts at position=0x%08X (%d)", content_start_position, content_start_position);
 
@@ -363,36 +353,12 @@ public class Parser {
 						System.out.println(blockUtf8);
 					}
 
-					if (opt_output && convertedDoc != null) {
-						try {
-							convertedDoc.addText(blockUtf8);
-						} catch (Exception e) {
-							LOGGER.error("error adding text to converted document", e);
-						}
-					}
-
 					blockPosition = blockPosition + 4 + blockLen;
 					contentBlockIndex++;
 				}
 
 				doc.setContent(contentBuilder.toString());
 				println("content ends at position=0x%08X (%d)", contentEndPosition, contentEndPosition);
-
-				if (opt_output && convertedDoc != null) {
-					String convertedFileName = opt_file.replace(".cwk", ".odt");
-
-					if (new File(convertedFileName).exists()) {
-						LOGGER.error("unable to save converted document. '{}' exists.", convertedFileName);
-					} else {
-						try {
-							convertedDoc.save(convertedFileName);
-							convertedDoc.close();
-							println("Saved converted document: %s", convertedFileName);
-						} catch (Exception e) {
-							LOGGER.error("error saving converted document", e);
-						}
-					}
-				}
 			}
 
 			// Verify file end marker
@@ -401,6 +367,8 @@ public class Parser {
 				println("File end marker found at: 0x%08X (%d)", endMarkerPos, endMarkerPos);
 			}
 		}
+
+		return doc;
 	}
 
 	/**
@@ -594,7 +562,9 @@ public class Parser {
 	}
 
 	public void println(String line, Object... args) {
-		System.out.format(line + "\n", args);
+		if (opt_verbose) {
+			System.out.format(line + "\n", args);
+		}
 	}
 
 	/**


### PR DESCRIPTION
- Upgrade odfdom-java from 0.8.7 to 0.12.0
- Add OdfWriter class for converting parsed documents to ODF format
  - Sets page dimensions, margins, and orientation
  - Creates font styles from document fonts
  - Converts text content to ODF paragraphs
- Add BatchConverter for bulk CWK to ODT conversion
- Refactor Parser to expose parse() method returning Document
- Add convert_all.sh script for batch converting test files
- Update .gitignore for test output directory and build artifacts