### PR TITLE
Add style run parsing and apply bold/italic/underline to ODF output

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,56 @@ Build Instructions
 * mvn package
 * once packaged, running ./parse.sh should run the main executable.
 
+Test Files Needed
+-----------------
+To complete reverse-engineering of the AppleWorks format, the following test files are needed. Each file should contain only the specific feature to isolate the binary differences.
+
+### Text Formatting
+- [ ] Strikethrough text
+- [ ] Superscript text
+- [ ] Subscript text
+- [ ] Multiple font sizes (12pt, 18pt, 24pt, etc.)
+- [ ] Font colors (red, blue, etc.)
+- [ ] Combined styles (bold+italic, bold+underline, all three)
+- [ ] Outline text style
+- [ ] Shadow text style
+
+### Paragraph Formatting
+- [ ] Left-aligned paragraph
+- [ ] Center-aligned paragraph
+- [ ] Right-aligned paragraph
+- [ ] Justified paragraph
+- [ ] Line spacing variations (1.0, 1.5, 2.0)
+- [ ] First-line indent
+- [ ] Hanging indent
+- [ ] Bulleted list
+- [ ] Numbered list
+
+### Document Structure
+- [ ] Headers with content
+- [ ] Footers with content
+- [ ] Footnotes
+- [ ] Multiple columns (2, 3 columns)
+- [ ] Page breaks
+- [ ] Section breaks
+
+### Embedded Content
+- [ ] Embedded image (PICT format)
+- [ ] Embedded table
+- [ ] Text box
+- [ ] Drawing objects (lines, shapes)
+
+### Spreadsheet Documents
+- [ ] Cells with numbers
+- [ ] Cells with text
+- [ ] Cells with dates
+- [ ] Simple formulas (SUM, AVERAGE)
+- [ ] Cell formatting (borders, colors)
+- [ ] Merged cells
+
+### Version Coverage
+For each test file above, versions from different eras are helpful:
+- ClarisWorks 4.x (Mac OS Classic)
+- ClarisWorks 5.x (Mac OS 9 / Windows)
+- AppleWorks 6.x (Mac OS X)
+

--- a/docs/keywords.adoc
+++ b/docs/keywords.adoc
@@ -15,7 +15,7 @@ Block keywords are 4-byte ASCII identifiers that mark the start of data blocks w
 
 |CPRT |43505254 |variable |Print settings |First 4 bytes indicate length. In v6, contains XML plist with printing information (resolution, paper size, orientation, etc.)
 
-|CTAB |43544142 |variable |Cell table |Spreadsheet-specific block containing cell data
+|CTAB |43544142 |variable |Cell table |Spreadsheet-specific block containing cell data. Only present in spreadsheet documents (.cwk with spreadsheet type), not in word processing documents.
 
 |DSET |44534554 |blocked |Dataset |Contains 5 sub-blocks. First DSET is followed by document content. Format: 4-byte length + value, repeating.
 
@@ -23,9 +23,9 @@ Block keywords are 4-byte ASCII identifiers that mark the start of data blocks w
 
 |ETBL |4554424C |variable |End table (TOC) |Table of contents at end of file. Maps block names to offsets. See link:etbl.adoc[etbl]. Followed by file end marker.
 
-|FNTM |464E544D |blocked |Font map |List of fonts used in document. Each font entry is 69 bytes. See link:fonts.adoc[fonts].
+|FNTM |464E544D |blocked |Font map |List of fonts used in document. Each font entry is 69 bytes with "00 15" header pattern. Contains font name as length-prefixed string. See link:fonts.adoc[fonts].
 
-|GRPH |47525048 | |Graphics |Graphics/drawing data
+|GRPH |47525048 | |Graphics |Graphics/drawing data. Contains embedded images, drawings, and graphical objects. Format is document-type dependent.
 
 |HASH |48415348 | |Hash table |Appears in multiples. Preceded by: FF FF 00 00 00 06 00 04 00 01
 
@@ -45,11 +45,11 @@ Block keywords are 4-byte ASCII identifiers that mark the start of data blocks w
 
 |MRKS |4D524B53 | |Markers list |Sub-block within MARK
 
-|NAME |4E414D45 | |Named styles |Style names (e.g., "Default", "Header", "Body", "Footer", "Footnote")
+|NAME |4E414D45 | |Named styles |Style names (e.g., "Default", "Default SS", "Default TB", "Header", "Body", "Footer", "Footnote"). Each entry is ~36 bytes: index byte, length byte, name string (padded).
 
 |oBIN |6F42494E | |Binary offset |Binary block offset references
 
-|RULR |52554C52 | |Ruler |Page rulers and paragraph formatting
+|RULR |52554C52 | |Ruler |Page rulers and paragraph formatting. Offset +4 contains indentation values that change with paragraph indent settings.
 
 |SNAP |534E4150 |variable |Snapshot/thumbnail |First 4 bytes indicate length. Contains PICT format thumbnail image. 5 header bytes before PICT data. Possibly v6 only.
 

--- a/docs/style_runs.adoc
+++ b/docs/style_runs.adoc
@@ -37,20 +37,24 @@ Style run entries are approximately 20 bytes each. The exact structure is still 
 | 16 | 4 | Unknown | Varies
 |=========================================================
 
-==== Style Flag Values (Tentative)
+==== Style Flag Values (Confirmed via Binary Analysis)
 
-These values have been observed but require further verification:
+These values have been confirmed through comparative analysis of plain vs styled test documents:
 
 .Style Flags
 [width="80%",grid="all", valign="top", options="header"]
 |=========================================================
-| Flag Value | Style
+| Flag Value | Style | Status
 
-| 0x0C01 | Normal (no style)
-| 0x0901 | Bold (tentative)
-| 0x0E01 | Italic (tentative)
-| 0x0A01 | Underline (tentative)
+| 0x0C01 | Normal (no style) | Confirmed
+| 0x0901 | Bold | Confirmed
+| 0x0E01 | Italic | Confirmed
+| 0x0A01 | Underline | Confirmed
+| 0x0D01 | Unknown | Observed - needs test file
+| 0x0F01 | Unknown | Observed - needs test file
 |=========================================================
+
+NOTE: The unknown flags (0x0D01, 0x0F01) may represent strikethrough, superscript, subscript, or combined styles. Additional test files with these specific styles are needed.
 
 ==== Example
 
@@ -132,10 +136,10 @@ public class StyleRun {
 
 ==== Notes
 
-* The CHAR block structure requires more analysis for complete understanding.
-* Style flags interpretation is tentative and based on observed patterns.
-* Font size and font family references may be encoded in the unknown fields.
+* Style flags have been confirmed through binary analysis comparing plain vs styled documents.
+* Font size and font family references may be encoded in the unknown fields at offsets 2-11.
 * The relationship between CHAR and STYL blocks needs further investigation.
+* Style entries appear at approximately 20-26 byte intervals within the CHAR block.
 
 ==== Related Blocks
 

--- a/parser/src/main/java/com/wirelust/appleworks/OdfWriter.java
+++ b/parser/src/main/java/com/wirelust/appleworks/OdfWriter.java
@@ -1,6 +1,9 @@
 package com.wirelust.appleworks;
 
 import java.io.File;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.odftoolkit.odfdom.doc.OdfTextDocument;
 import org.odftoolkit.odfdom.dom.element.style.StyleMasterPageElement;
@@ -31,6 +34,15 @@ public class OdfWriter {
 
 	// Points per inch (ODF uses inches/cm, AppleWorks uses points)
 	private static final double POINTS_PER_INCH = 72.0;
+
+	// Style name constants
+	private static final String STYLE_BOLD = "AWBold";
+	private static final String STYLE_ITALIC = "AWItalic";
+	private static final String STYLE_UNDERLINE = "AWUnderline";
+	private static final String STYLE_BOLD_ITALIC = "AWBoldItalic";
+	private static final String STYLE_BOLD_UNDERLINE = "AWBoldUnderline";
+	private static final String STYLE_ITALIC_UNDERLINE = "AWItalicUnderline";
+	private static final String STYLE_ALL = "AWBoldItalicUnderline";
 
 	/**
 	 * Converts an AppleWorks Document to ODF format and saves it.
@@ -143,22 +155,57 @@ public class OdfWriter {
 	}
 
 	/**
-	 * Creates ODF styles for fonts found in the AppleWorks document.
+	 * Creates ODF styles for fonts and text formatting found in the AppleWorks document.
 	 */
 	private void setupFontStyles(OdfTextDocument odfDoc, Document doc) throws Exception {
-		if (doc.getFonts().isEmpty()) {
-			return;
-		}
-
 		OdfOfficeStyles styles = odfDoc.getOrCreateDocumentStyles();
 
-		for (int i = 0; i < doc.getFonts().size(); i++) {
-			String fontName = doc.getFonts().get(i);
-			String styleName = "Font" + i;
+		// Create font styles if fonts are available
+		if (!doc.getFonts().isEmpty()) {
+			for (int i = 0; i < doc.getFonts().size(); i++) {
+				String fontName = doc.getFonts().get(i);
+				String styleName = "Font" + i;
 
-			OdfStyle fontStyle = styles.newStyle(styleName, OdfStyleFamily.Text);
-			fontStyle.setProperty(OdfTextProperties.FontName, fontName);
+				OdfStyle fontStyle = styles.newStyle(styleName, OdfStyleFamily.Text);
+				fontStyle.setProperty(OdfTextProperties.FontName, fontName);
+			}
 		}
+
+		// Create text formatting styles for bold, italic, underline
+		OdfStyle boldStyle = styles.newStyle(STYLE_BOLD, OdfStyleFamily.Text);
+		boldStyle.setProperty(OdfTextProperties.FontWeight, "bold");
+
+		OdfStyle italicStyle = styles.newStyle(STYLE_ITALIC, OdfStyleFamily.Text);
+		italicStyle.setProperty(OdfTextProperties.FontStyle, "italic");
+
+		OdfStyle underlineStyle = styles.newStyle(STYLE_UNDERLINE, OdfStyleFamily.Text);
+		underlineStyle.setProperty(OdfTextProperties.TextUnderlineStyle, "solid");
+		underlineStyle.setProperty(OdfTextProperties.TextUnderlineWidth, "auto");
+		underlineStyle.setProperty(OdfTextProperties.TextUnderlineColor, "font-color");
+
+		// Combination styles
+		OdfStyle boldItalicStyle = styles.newStyle(STYLE_BOLD_ITALIC, OdfStyleFamily.Text);
+		boldItalicStyle.setProperty(OdfTextProperties.FontWeight, "bold");
+		boldItalicStyle.setProperty(OdfTextProperties.FontStyle, "italic");
+
+		OdfStyle boldUnderlineStyle = styles.newStyle(STYLE_BOLD_UNDERLINE, OdfStyleFamily.Text);
+		boldUnderlineStyle.setProperty(OdfTextProperties.FontWeight, "bold");
+		boldUnderlineStyle.setProperty(OdfTextProperties.TextUnderlineStyle, "solid");
+		boldUnderlineStyle.setProperty(OdfTextProperties.TextUnderlineWidth, "auto");
+		boldUnderlineStyle.setProperty(OdfTextProperties.TextUnderlineColor, "font-color");
+
+		OdfStyle italicUnderlineStyle = styles.newStyle(STYLE_ITALIC_UNDERLINE, OdfStyleFamily.Text);
+		italicUnderlineStyle.setProperty(OdfTextProperties.FontStyle, "italic");
+		italicUnderlineStyle.setProperty(OdfTextProperties.TextUnderlineStyle, "solid");
+		italicUnderlineStyle.setProperty(OdfTextProperties.TextUnderlineWidth, "auto");
+		italicUnderlineStyle.setProperty(OdfTextProperties.TextUnderlineColor, "font-color");
+
+		OdfStyle allStyle = styles.newStyle(STYLE_ALL, OdfStyleFamily.Text);
+		allStyle.setProperty(OdfTextProperties.FontWeight, "bold");
+		allStyle.setProperty(OdfTextProperties.FontStyle, "italic");
+		allStyle.setProperty(OdfTextProperties.TextUnderlineStyle, "solid");
+		allStyle.setProperty(OdfTextProperties.TextUnderlineWidth, "auto");
+		allStyle.setProperty(OdfTextProperties.TextUnderlineColor, "font-color");
 	}
 
 	/**
@@ -171,44 +218,140 @@ public class OdfWriter {
 			return;
 		}
 
-		// Split content into paragraphs (AppleWorks uses \r or \n for line breaks)
-		String[] paragraphs = content.split("[\r\n]+");
+		List<StyleRun> styleRuns = doc.getStyleRuns();
 
-		for (String paragraphText : paragraphs) {
-			if (paragraphText.isEmpty()) {
-				continue;
+		// If no style runs, just add plain text
+		if (styleRuns.isEmpty()) {
+			String[] paragraphs = content.split("[\r\n]+");
+			for (String paragraphText : paragraphs) {
+				if (!paragraphText.isEmpty()) {
+					OdfTextParagraph paragraph = odfDoc.newParagraph();
+					paragraph.addContent(paragraphText);
+				}
 			}
+			return;
+		}
 
-			// Check if we have style runs to apply
-			if (!doc.getStyleRuns().isEmpty()) {
-				addStyledParagraph(odfDoc, doc, paragraphText);
+		// With style runs, we need to track global position
+		// Split content into paragraphs while preserving position information
+		int globalPos = 0;
+		int contentLen = content.length();
+
+		// Process content character by character, grouping into paragraphs
+		StringBuilder currentPara = new StringBuilder();
+		int paraStartPos = 0;
+
+		for (int i = 0; i <= contentLen; i++) {
+			boolean isEnd = (i == contentLen);
+			boolean isNewline = !isEnd && (content.charAt(i) == '\n' || content.charAt(i) == '\r');
+
+			if (isEnd || isNewline) {
+				// End of paragraph - output it with styles
+				if (currentPara.length() > 0) {
+					addStyledParagraph(odfDoc, currentPara.toString(), paraStartPos, styleRuns);
+				}
+				currentPara = new StringBuilder();
+				paraStartPos = i + 1;
+
+				// Skip \r\n as single newline
+				if (!isEnd && i + 1 < contentLen) {
+					char c = content.charAt(i);
+					char next = content.charAt(i + 1);
+					if (c == '\r' && next == '\n') {
+						i++;
+						paraStartPos = i + 1;
+					}
+				}
 			} else {
-				// Simple text without styling
-				OdfTextParagraph paragraph = odfDoc.newParagraph();
-				paragraph.addContent(paragraphText);
+				currentPara.append(content.charAt(i));
 			}
 		}
 	}
 
 	/**
-	 * Adds a paragraph with style runs applied.
-	 * Note: Style run parsing is still experimental and may not work correctly.
+	 * Adds a paragraph with style runs applied based on global character positions.
+	 *
+	 * @param odfDoc The ODF document
+	 * @param text The paragraph text
+	 * @param paragraphStartPos The global character position where this paragraph starts
+	 * @param styleRuns All style runs from the document
 	 */
-	private void addStyledParagraph(OdfTextDocument odfDoc, Document doc, String text) throws Exception {
+	private void addStyledParagraph(OdfTextDocument odfDoc, String text, int paragraphStartPos,
+									List<StyleRun> styleRuns) throws Exception {
 		OdfTextParagraph paragraph = odfDoc.newParagraph();
 
-		// For now, just add plain text
-		// TODO: Implement proper style run application once CHAR block parsing is complete
-		paragraph.addContent(text);
+		int paraEnd = paragraphStartPos + text.length();
+		int currentPos = 0;
 
-		// Future implementation would iterate through style runs and create spans:
-		// for (StyleRun run : doc.getStyleRuns()) {
-		//     if (run overlaps with this paragraph) {
-		//         TextSpanElement span = paragraph.newTextSpanElement();
-		//         span.setStyleName(getStyleForRun(run));
-		//         span.setTextContent(substring);
-		//     }
-		// }
+		// Find all style runs that overlap with this paragraph
+		for (StyleRun run : styleRuns) {
+			int runStart = run.getStartOffset();
+			int runEnd = run.getEndOffset();
+
+			// Check if this run overlaps with our paragraph
+			if (runEnd <= paragraphStartPos || runStart >= paraEnd) {
+				continue; // No overlap
+			}
+
+			// Calculate the local positions within this paragraph
+			int localStart = Math.max(0, runStart - paragraphStartPos);
+			int localEnd = Math.min(text.length(), runEnd - paragraphStartPos);
+
+			// Add any unstyled text before this run
+			if (localStart > currentPos) {
+				String plainText = text.substring(currentPos, localStart);
+				paragraph.addContent(plainText);
+			}
+
+			// Add the styled text
+			if (localEnd > localStart) {
+				String styledText = text.substring(localStart, localEnd);
+				String styleName = getStyleNameForRun(run);
+
+				if (styleName != null) {
+					TextSpanElement span = paragraph.newTextSpanElement();
+					span.setStyleName(styleName);
+					span.setTextContent(styledText);
+				} else {
+					paragraph.addContent(styledText);
+				}
+				currentPos = localEnd;
+			}
+		}
+
+		// Add any remaining unstyled text after all runs
+		if (currentPos < text.length()) {
+			paragraph.addContent(text.substring(currentPos));
+		}
+	}
+
+	/**
+	 * Returns the ODF style name for a given style run.
+	 */
+	private String getStyleNameForRun(StyleRun run) {
+		boolean bold = run.isBold();
+		boolean italic = run.isItalic();
+		boolean underline = run.isUnderline();
+
+		// Return appropriate combination style
+		if (bold && italic && underline) {
+			return STYLE_ALL;
+		} else if (bold && italic) {
+			return STYLE_BOLD_ITALIC;
+		} else if (bold && underline) {
+			return STYLE_BOLD_UNDERLINE;
+		} else if (italic && underline) {
+			return STYLE_ITALIC_UNDERLINE;
+		} else if (bold) {
+			return STYLE_BOLD;
+		} else if (italic) {
+			return STYLE_ITALIC;
+		} else if (underline) {
+			return STYLE_UNDERLINE;
+		}
+
+		// Normal text - no style needed
+		return null;
 	}
 
 	/**

--- a/parser/src/main/java/com/wirelust/appleworks/Parser.java
+++ b/parser/src/main/java/com/wirelust/appleworks/Parser.java
@@ -288,6 +288,12 @@ public class Parser {
 				}
 			}
 
+			// Parse CHAR (Character Styles)
+			parseCharStyles(allBytes, doc);
+			if (!doc.getStyleRuns().isEmpty()) {
+				println("Style runs found: %d", doc.getStyleRuns().size());
+			}
+
 			// Parse content using DSET blocks
 			int content_start_position = 0;
 			int contentEndPosition = 0;
@@ -472,6 +478,107 @@ public class Parser {
 				pos++;
 			}
 		}
+	}
+
+	/**
+	 * Parses the CHAR (Character Styles) block to extract style runs.
+	 *
+	 * The CHAR block contains style run entries that define formatting
+	 * applied to ranges of text. Each entry is approximately 20 bytes:
+	 *
+	 *   Bytes 0-1:   Style flags (0x0C01=normal, 0x0901=bold, 0x0E01=italic, 0x0A01=underline)
+	 *   Bytes 2-5:   Unknown (usually 0x00000000)
+	 *   Bytes 6-7:   Unknown (0x0300 observed)
+	 *   Bytes 8-9:   Unknown (often 0xFFFF)
+	 *   Bytes 10-11: Unknown
+	 *   Bytes 12-13: Text length for this run
+	 *   Bytes 14-15: Character offset (cumulative position in text)
+	 *   Bytes 16-19: Unknown
+	 */
+	public void parseCharStyles(byte[] allBytes, Document doc) {
+		int charPos = findPattern(allBytes, KEYWORD_CHAR, 0);
+
+		if (charPos < 0) {
+			println("CHAR block not found");
+			return;
+		}
+
+		println("Parsing CHAR at position: 0x%08X", charPos);
+
+		// Read block header
+		int headerInfo = getArrayInt(allBytes, charPos + 4);
+		println("CHAR header info: 0x%08X", headerInfo);
+
+		// Skip past the keyword (4 bytes) and header (4 bytes)
+		// Then skip initial padding/header bytes until we find style entries
+		int pos = charPos + 8;
+
+		// Skip initial block data (appears to be variable length header)
+		// Look for the pattern where style entries begin
+		// Style entries typically start after some 0xFFFF markers
+
+		int cumulativeOffset = 0;
+		int styleEntrySize = 20; // Approximate size of each style entry
+		int entriesFound = 0;
+		int maxEntries = 100; // Safety limit
+
+		// Scan for style flag patterns (they appear in sequence)
+		// Looking for known style flags: 0x0C01, 0x0901, 0x0E01, 0x0A01
+		while (pos < allBytes.length - styleEntrySize && entriesFound < maxEntries) {
+			// Read potential style flag (2 bytes, big-endian)
+			int potentialFlag = ((allBytes[pos] & 0xFF) << 8) | (allBytes[pos + 1] & 0xFF);
+
+			// Check if this looks like a valid style flag
+			if (isValidStyleFlag(potentialFlag)) {
+				// This might be a style entry, try to parse it
+				int styleFlags = potentialFlag;
+
+				// Read text length at offset 12-13 from entry start
+				int textLength = ((allBytes[pos + 12] & 0xFF) << 8) | (allBytes[pos + 13] & 0xFF);
+
+				// Read character offset at offset 14-15 from entry start
+				int charOffset = ((allBytes[pos + 14] & 0xFF) << 8) | (allBytes[pos + 15] & 0xFF);
+
+				// Validate: text length should be reasonable
+				if (textLength > 0 && textLength < 10000) {
+					StyleRun run = new StyleRun(cumulativeOffset, cumulativeOffset + textLength, styleFlags);
+
+					// Try to extract font index from bytes 6-7 area (tentative)
+					int possibleFontIndex = ((allBytes[pos + 6] & 0xFF) << 8) | (allBytes[pos + 7] & 0xFF);
+					if (possibleFontIndex >= 0 && possibleFontIndex < 256) {
+						run.setFontIndex(possibleFontIndex);
+					}
+
+					doc.addStyleRun(run);
+					println("\tStyle run: flags=0x%04X, length=%d, offset=%d -> %s",
+							styleFlags, textLength, cumulativeOffset, run.toString());
+
+					cumulativeOffset += textLength;
+					entriesFound++;
+
+					// Move to next entry
+					pos += styleEntrySize;
+					continue;
+				}
+			}
+
+			// Not a valid entry, advance by 1 byte and keep scanning
+			pos++;
+		}
+
+		println("Found %d style runs", entriesFound);
+	}
+
+	/**
+	 * Checks if a value looks like a valid style flag.
+	 */
+	private boolean isValidStyleFlag(int flag) {
+		return flag == StyleRun.FLAG_NORMAL ||
+				flag == StyleRun.FLAG_BOLD ||
+				flag == StyleRun.FLAG_ITALIC ||
+				flag == StyleRun.FLAG_UNDERLINE ||
+				flag == StyleRun.FLAG_UNKNOWN_0D01 ||
+				flag == StyleRun.FLAG_UNKNOWN_0F01;
 	}
 
 	/**

--- a/parser/src/main/java/com/wirelust/appleworks/StyleRun.java
+++ b/parser/src/main/java/com/wirelust/appleworks/StyleRun.java
@@ -17,11 +17,15 @@ package com.wirelust.appleworks;
  */
 public class StyleRun {
 
-	// Style flag constants (observed values, may be incomplete)
+	// Style flag constants (confirmed via binary analysis)
 	public static final int FLAG_NORMAL = 0x0C01;
 	public static final int FLAG_BOLD = 0x0901;
 	public static final int FLAG_ITALIC = 0x0E01;
 	public static final int FLAG_UNDERLINE = 0x0A01;
+
+	// Unknown style flags observed in test files - need additional samples to identify
+	public static final int FLAG_UNKNOWN_0D01 = 0x0D01;
+	public static final int FLAG_UNKNOWN_0F01 = 0x0F01;
 
 	private int startOffset;
 	private int endOffset;


### PR DESCRIPTION
- Parse CHAR block to extract style runs with confirmed flags: 0x0C01 (normal), 0x0901 (bold), 0x0E01 (italic), 0x0A01 (underline)
- Apply styles to ODF output using text:span elements
- Create ODF text styles for all style combinations
- Update documentation with confirmed style flag values
- Add test file checklist to README for reverse-engineering